### PR TITLE
Enable design banners in canvas

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -22,7 +22,9 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   console.log('Game config:', campaign.gameConfig);
   console.log('Button config:', campaign.buttonConfig);
 
-  const gameBackgroundImage = campaign.gameConfig?.[campaign.type]?.backgroundImage;
+  const gameBackgroundImage =
+    campaign.gameConfig?.[campaign.type]?.backgroundImage ||
+    campaign.design?.backgroundImage;
   const buttonLabel = campaign.gameConfig?.[campaign.type]?.buttonLabel || campaign.buttonConfig?.text || 'Jouer';
   const buttonColor = campaign.buttonConfig?.color || campaign.gameConfig?.[campaign.type]?.buttonColor || '#841b60';
 

--- a/src/components/ModernEditor/ModernEditorCanvas.tsx
+++ b/src/components/ModernEditor/ModernEditorCanvas.tsx
@@ -22,6 +22,11 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
       width: '100%',
       height: '100%',
       backgroundColor: campaign.design?.background || '#f8fafc',
+      backgroundImage: campaign.design?.backgroundImage
+        ? `url(${campaign.design.backgroundImage})`
+        : undefined,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
       transition: 'all 0.3s ease',
     };
 
@@ -83,16 +88,128 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
     }
   };
 
+  const headerBanner = campaign.design?.headerBanner;
+  const footerBanner = campaign.design?.footerBanner;
+  const headerText = campaign.design?.headerText;
+  const footerText = campaign.design?.footerText;
+  const customText = campaign.design?.customText;
+
+  const sizeMap: Record<string, string> = {
+    small: '0.875rem',
+    medium: '1rem',
+    large: '1.25rem'
+  };
+
+  const customTextPosition: Record<string, React.CSSProperties> = {
+    top: { top: '8px', left: '50%', transform: 'translateX(-50%)' },
+    bottom: { bottom: '8px', left: '50%', transform: 'translateX(-50%)' },
+    left: { left: '8px', top: '50%', transform: 'translateY(-50%)' },
+    right: { right: '8px', top: '50%', transform: 'translateY(-50%)' },
+    center: { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+  };
+
   console.log('Enhanced campaign for preview:', enhancedCampaign);
 
   return (
     <div className="w-full h-full flex items-center justify-center bg-gray-100 p-4">
-      <div style={getCanvasStyle()}>
-        <GameCanvasPreview 
-          campaign={enhancedCampaign}
-          className="w-full h-full"
-          key={`preview-${gameSize}-${gamePosition}-${campaign.buttonConfig?.color}-${JSON.stringify(campaign.gameConfig?.[campaign.type])}`}
-        />
+      <div style={getCanvasStyle()} className="flex flex-col h-full w-full relative">
+        {headerBanner?.enabled && (
+          <div
+            className="relative w-full"
+            style={{
+              backgroundImage: `url(${headerBanner.image})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              height: headerBanner.height || '120px'
+            }}
+          >
+            {headerBanner.overlay && (
+              <div className="absolute inset-0 bg-black opacity-40" />
+            )}
+            {headerText?.enabled && (
+              <div
+                className="relative w-full text-center flex items-center justify-center h-full"
+                style={{
+                  color: headerText.color,
+                  fontSize: sizeMap[headerText.size] || '1rem',
+                  ...(headerText.showFrame
+                    ? {
+                        backgroundColor: headerText.frameColor,
+                        border: `1px solid ${headerText.frameBorderColor}`,
+                        padding: '4px 8px',
+                        borderRadius: '4px'
+                      }
+                    : {})
+                }}
+              >
+                {headerText.text}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex-1 flex relative">
+          <GameCanvasPreview
+            campaign={enhancedCampaign}
+            className="w-full h-full"
+            key={`preview-${gameSize}-${gamePosition}-${campaign.buttonConfig?.color}-${JSON.stringify(campaign.gameConfig?.[campaign.type])}`}
+          />
+          {customText?.enabled && (
+            <div
+              style={{
+                position: 'absolute',
+                ...customTextPosition[customText.position || 'top'],
+                color: customText.color,
+                fontSize: sizeMap[customText.size] || '1rem',
+                ...(customText.showFrame
+                  ? {
+                      backgroundColor: customText.frameColor,
+                      border: `1px solid ${customText.frameBorderColor}`,
+                      padding: '4px 8px',
+                      borderRadius: '4px'
+                    }
+                  : {})
+              }}
+            >
+              {customText.text}
+            </div>
+          )}
+        </div>
+
+        {footerBanner?.enabled && (
+          <div
+            className="relative w-full"
+            style={{
+              backgroundImage: `url(${footerBanner.image})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              height: footerBanner.height || '120px'
+            }}
+          >
+            {footerBanner.overlay && (
+              <div className="absolute inset-0 bg-black opacity-40" />
+            )}
+            {footerText?.enabled && (
+              <div
+                className="relative w-full text-center flex items-center justify-center h-full"
+                style={{
+                  color: footerText.color,
+                  fontSize: sizeMap[footerText.size] || '1rem',
+                  ...(footerText.showFrame
+                    ? {
+                        backgroundColor: footerText.frameColor,
+                        border: `1px solid ${footerText.frameBorderColor}`,
+                        padding: '4px 8px',
+                        borderRadius: '4px'
+                      }
+                    : {})
+                }}
+              >
+                {footerText.text}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -240,6 +240,9 @@ const Step3VisualStyle: React.FC = () => {
               <div
                 className="border-2 border-dashed border-gray-300 rounded-2xl p-8 text-center bg-gray-50"
                 onClick={() => fileInputRef.current?.click()}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && fileInputRef.current?.click()}
               >
                 <Upload className="w-12 h-12 text-gray-400 mx-auto mb-4" />
                 {backgroundImage ? <div>

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { ArrowLeft, Upload, Eye, Settings, CheckCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useQuickCampaignStore } from '../../stores/quickCampaignStore';
@@ -30,6 +30,7 @@ const Step3VisualStyle: React.FC = () => {
   const [isCreating, setIsCreating] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [creationSuccess, setCreationSuccess] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const handleFileUpload = (files: FileList | null) => {
     if (files && files[0]) {
       setBackgroundImage(files[0]);
@@ -236,7 +237,10 @@ const Step3VisualStyle: React.FC = () => {
               <h3 className="text-2xl font-light text-gray-900 mb-8">
                 Image de fond <span className="text-gray-400 font-light">(optionnel)</span>
               </h3>
-              <div className="border-2 border-dashed border-gray-300 rounded-2xl p-8 text-center bg-gray-50">
+              <div
+                className="border-2 border-dashed border-gray-300 rounded-2xl p-8 text-center bg-gray-50"
+                onClick={() => fileInputRef.current?.click()}
+              >
                 <Upload className="w-12 h-12 text-gray-400 mx-auto mb-4" />
                 {backgroundImage ? <div>
                     <p className="text-gray-900 font-medium mb-2">
@@ -249,7 +253,13 @@ const Step3VisualStyle: React.FC = () => {
                     <p className="text-gray-600 mb-2">
                       <label className="text-[#841b60] cursor-pointer hover:text-[#841b60]/80 transition-colors">
                         Téléchargez une image de fond
-                        <input type="file" accept="image/*" onChange={e => handleFileUpload(e.target.files)} className="hidden" />
+                        <input
+                          ref={fileInputRef}
+                          type="file"
+                          accept="image/*"
+                          onChange={e => handleFileUpload(e.target.files)}
+                          className="hidden"
+                        />
                       </label>
                     </p>
                     <p className="text-gray-400 text-sm">PNG, JPG jusqu'à 10MB</p>

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -56,7 +56,7 @@ const Step3VisualStyle: React.FC = () => {
           hasBackgroundImage: !!backgroundImage,
           customColors,
           jackpotColors,
-          ...(selectedGameType === 'roue' && {
+          ...(selectedGameType === 'wheel' && {
             segmentCount,
             roulette: {
               segments: Array.from({
@@ -119,7 +119,7 @@ const Step3VisualStyle: React.FC = () => {
           hasBackgroundImage: !!backgroundImage,
           customColors,
           jackpotColors,
-          ...(selectedGameType === 'roue' && {
+          ...(selectedGameType === 'wheel' && {
             segmentCount,
             roulette: {
               segments: Array.from({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -101,8 +101,8 @@ const Dashboard: React.FC = () => {
       <div className="px-6 space-y-6">
         {/* Quick Action Section */}
         <div className="flex justify-center mt-6">
-          <Link 
-            to="/campaign/quick"
+          <Link
+            to="/quick-campaign"
             className="inline-flex items-center px-8 py-4 bg-gradient-to-r from-[#841b60] to-[#a855f7] text-white font-semibold rounded-2xl hover:from-[#6d164f] hover:to-[#9333ea] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1"
           >
             <Zap className="w-6 h-6 mr-3" />


### PR DESCRIPTION
## Summary
- show campaign design background image
- support header/footer banners and custom text overlays in editor canvas

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421526a13c832a87ec71dec1253cb9