### PR TITLE
Fix funnel usage in quick campaign preview

### DIFF
--- a/src/components/QuickCampaign/Preview/PreviewContent.tsx
+++ b/src/components/QuickCampaign/Preview/PreviewContent.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import GameRenderer from './GameRenderer';
+import FunnelUnlockedGame from '../../funnels/FunnelUnlockedGame';
+import FunnelStandard from '../../funnels/FunnelStandard';
 import MobilePreview from '../../CampaignEditor/Mobile/MobilePreview';
 
 interface PreviewContentProps {
@@ -30,6 +31,21 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
   customColors,
   jackpotColors
 }) => {
+  const unlockedTypes = ['wheel', 'scratch', 'jackpot', 'dice'];
+
+  const getFunnelComponent = () => {
+    if (unlockedTypes.includes(selectedGameType)) {
+      return (
+        <FunnelUnlockedGame
+          campaign={mockCampaign}
+          previewMode={selectedDevice === 'desktop' ? 'desktop' : selectedDevice}
+          modalContained={false}
+        />
+      );
+    }
+    return <FunnelStandard campaign={mockCampaign} />;
+  };
+
   const renderDesktopPreview = () => (
     <div className="w-full h-full flex items-center justify-center bg-gray-50 relative overflow-hidden">
       {/* Background image if available */}
@@ -43,27 +59,8 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
       )}
       
       {/* Content container */}
-      <div className="relative z-10 max-w-2xl mx-auto p-8 text-center">
-        <div className="mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            {mockCampaign.screens?.[0]?.title || 'Tentez votre chance !'}
-          </h1>
-          <p className="text-lg text-gray-600">
-            {mockCampaign.screens?.[0]?.description || 'Participez pour avoir une chance de gagner !'}
-          </p>
-        </div>
-        
-        {/* Game Component */}
-        <div className="flex justify-center">
-          <GameRenderer
-            gameType={selectedGameType || 'wheel'}
-            mockCampaign={mockCampaign}
-            customColors={customColors}
-            jackpotColors={jackpotColors}
-            gameSize={mockCampaign.gameSize || 'large'}
-            gamePosition={mockCampaign.gamePosition || 'center'}
-          />
-        </div>
+      <div className="relative z-10 max-w-2xl mx-auto p-8">
+        {getFunnelComponent()}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- update quick campaign preview to use `FunnelUnlockedGame` or `FunnelStandard`

## Testing
- `npm run build` *(fails: vite not found before install)*
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842ac500880832a9b10542a3e258fa9