### PR TITLE
Adjust wheel cropping regardless of device

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -42,11 +42,10 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   console.log('Using gamePosition:', gamePosition);
   console.log('Using buttonLabel:', buttonLabel, 'buttonColor:', buttonColor);
 
-  // Check if we should crop the wheel (mobile + left/right/bottom positions for wheel games)
-  const isMobile = previewDevice === 'mobile';
+  // Crop the wheel whenever it is placed left, right or bottom
   const isWheelGame = campaign.type === 'wheel';
   const isCroppablePosition = ['left', 'right', 'bottom'].includes(gamePosition);
-  const shouldCropWheel = isMobile && isWheelGame && isCroppablePosition;
+  const shouldCropWheel = isWheelGame && isCroppablePosition;
 
   // Calculate positioning styles based on gamePosition
   const getPositionStyles = () => {
@@ -57,7 +56,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
       maxHeight: `${gameDimensions.height}px`,
     };
 
-    // For wheel games with mobile cropping, let WheelContainer handle positioning completely
+    // When cropping the wheel, let WheelContainer handle positioning completely
     if (shouldCropWheel) {
       return {
         width: '100%',

--- a/src/components/GameTypes/WheelComponents/WheelContainer.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelContainer.tsx
@@ -15,10 +15,9 @@ const WheelContainer: React.FC<WheelContainerProps> = ({
   gameDimensions,
   previewDevice
 }) => {
-  // Check if we're on mobile and position requires cropping
-  const isMobile = previewDevice === 'mobile';
+  // Crop the wheel when placed left, right or bottom
   const isCroppablePosition = ['left', 'right', 'bottom'].includes(gamePosition);
-  const shouldCropWheel = isMobile && isCroppablePosition;
+  const shouldCropWheel = isCroppablePosition;
 
   const getAbsolutePositionStyles = (): React.CSSProperties => {
     const containerStyle: React.CSSProperties = {
@@ -32,7 +31,7 @@ const WheelContainer: React.FC<WheelContainerProps> = ({
 
     const safeMargin = 20;
 
-    // For mobile cropping scenarios - position wheel to show only desired part
+    // When cropping, position the wheel so only the desired part is visible
     if (shouldCropWheel) {
       switch (gamePosition) {
         case 'left':

--- a/src/components/GameTypes/WheelComponents/WheelPointer.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPointer.tsx
@@ -29,12 +29,21 @@ const WheelPointer: React.FC<WheelPointerProps> = ({
     return canvasSize / 2 - pointerSize / 2;
   };
 
+  // Calcul de la position verticale du pointeur
+  const getPointerTop = () => {
+    if (shouldCropWheel && gamePosition === 'bottom') {
+      // Décaler vers le bas pour compenser le décalage de la roue
+      return canvasSize / 2 - pointerSize * 0.6;
+    }
+    return -pointerSize * 0.6;
+  };
+
   return (
     <div
       style={{
         position: 'absolute',
         left: getPointerLeft(),
-        top: -pointerSize * 0.6, // Ajuster pour que le pointeur touche le bord de la roue
+        top: getPointerTop(), // Ajuster pour que le pointeur touche le bord de la roue
         width: pointerSize,
         height: pointerSize * 1.6,
         zIndex: 3,

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -89,15 +89,17 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   const { getGameDimensions } = useGameSize(gameSize);
   const gameDimensions = getGameDimensions();
   
-  // Check if we're on mobile/tablet and position is left/right for 50% cropping
-  const isMobileTablet = previewDevice === 'mobile' || previewDevice === 'tablet';
-  const isLeftRightPosition = gamePosition === 'left' || gamePosition === 'right';
-  const shouldCropWheel = isMobileTablet && isLeftRightPosition;
+  // Determine if the wheel should be cropped based on its position
+  const isCroppablePosition = ['left', 'right', 'bottom'].includes(gamePosition);
+  const shouldCropWheel = isCroppablePosition;
   
   // Adjust canvas and container sizes for cropping
   const baseCanvasSize = Math.min(gameDimensions.width, gameDimensions.height) - 60;
   const canvasSize = baseCanvasSize;
-  const containerWidth = shouldCropWheel ? baseCanvasSize * 0.5 : baseCanvasSize;
+  const containerWidth =
+    shouldCropWheel && (gamePosition === 'left' || gamePosition === 'right')
+      ? baseCanvasSize * 0.5
+      : baseCanvasSize;
   
   // Taille du pointeur proportionnelle
   const pointerSize = Math.max(30, canvasSize * 0.08);
@@ -212,7 +214,10 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
             position: 'absolute',
             width: canvasSize - 15, // Réduit de 10 à 15
             height: canvasSize - 15,
-            left: shouldCropWheel ? (gamePosition === 'left' ? '8px' : `-${canvasSize * 0.5 + 8}px`) : '8px',
+            left:
+              shouldCropWheel && gamePosition === 'right'
+                ? `-${canvasSize * 0.5 + 8}px`
+                : '8px',
             top: '12px', // Légèrement augmenté pour moins d'ombre
             borderRadius: '50%',
             background: 'radial-gradient(circle, rgba(255,215,0,0.2) 0%, rgba(255,215,0,0.05) 50%, rgba(0,0,0,0.1) 100%)', // Réduit l'opacité
@@ -232,7 +237,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
           borderColor={borderColor}
           borderOutlineColor={borderOutlineColor}
           canvasSize={canvasSize}
-          offset={shouldCropWheel ? (gamePosition === 'left' ? '0px' : `-${canvasSize * 0.5}px`) : '0px'}
+          offset={shouldCropWheel && gamePosition === 'right' ? `-${canvasSize * 0.5}px` : '0px'}
         />
         
         {/* Theme decoration */}


### PR DESCRIPTION
## Summary
- crop wheel whenever positioned left, right or bottom
- adjust wheel pointer offset for bottom cropping

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842c5066374832aa5c2312719bbacb9