### PR TITLE
Fix mobile wheel clipping behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-LeadyaTest
+# Leadya Marketing Builder
+
+This project uses Vite to build the application.
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+## Build
+
+To create a production build, run:
+
+```bash
+npm run build
+```
+

--- a/src/components/GameTypes/MobileWheel/utils.ts
+++ b/src/components/GameTypes/MobileWheel/utils.ts
@@ -1,27 +1,24 @@
 
 export const getContainerWidth = (canvasSize: number, shouldCropWheel: boolean): number => {
   if (!shouldCropWheel) return canvasSize;
-  
-  // Pour les grandes tailles, on augmente la portion visible
-  if (canvasSize >= 500) {
-    return canvasSize * 0.65; // 65% au lieu de 50% pour les grandes roues
-  }
-  return canvasSize * 0.5; // 50% pour les petites roues
+
+  // Coupe toujours exactement la moitié de la roue
+  return canvasSize * 0.5;
 };
 
 export const getCanvasOffset = (
-  shouldCropWheel: boolean, 
+  shouldCropWheel: boolean,
   gamePosition: 'left' | 'right' | 'center' | 'top' | 'bottom',
   canvasSize: number
 ): string => {
   if (!shouldCropWheel) return '0px';
-  
+
   if (gamePosition === 'left') {
-    return '0px';
+    // Décale la roue pour n'afficher que sa moitié droite
+    return `-${canvasSize * 0.5}px`;
   } else { // right
-    // Pour les grandes tailles, on ajuste le décalage
-    const offset = canvasSize >= 500 ? canvasSize * 0.35 : canvasSize * 0.5;
-    return `-${offset}px`;
+    // Décale la roue pour n'afficher que sa moitié gauche
+    return '0px';
   }
 };
 

--- a/src/components/GameTypes/MobileWheelPreview.tsx
+++ b/src/components/GameTypes/MobileWheelPreview.tsx
@@ -90,17 +90,26 @@ const MobileWheelPreview: React.FC<MobileWheelPreviewProps> = ({
     }
   };
 
-  // Détermine si on doit couper la roue (positions left/right)
-  const shouldCropWheel = gamePosition === 'left' || gamePosition === 'right';
+  // Détermine si on doit couper la roue (positions left/right/bottom)
+  const shouldCropWheel = ['left', 'right', 'bottom'].includes(gamePosition);
+
+  const containerWidth =
+    shouldCropWheel && (gamePosition === 'left' || gamePosition === 'right')
+      ? canvasSize / 2
+      : canvasSize;
+
+  const containerHeight =
+    shouldCropWheel && gamePosition === 'bottom' ? canvasSize / 2 : canvasSize;
   
   // Offset pour le canvas dans le conteneur
   const getCanvasOffset = () => {
     if (!shouldCropWheel) return '0px';
-    return gamePosition === 'left' ? '0px' : `-${canvasSize / 2}px`;
+    if (gamePosition === 'right') return `-${canvasSize / 2}px`;
+    return '0px';
   };
 
   const renderWheelContainer = () => (
-    <div style={{ position: 'relative', width: canvasSize, height: canvasSize, overflow: 'hidden' }}>
+    <div style={{ position: 'relative', width: containerWidth, height: containerHeight, overflow: 'hidden' }}>
       <WheelCanvas
         segments={segments}
         centerImage={centerImage}
@@ -108,6 +117,15 @@ const MobileWheelPreview: React.FC<MobileWheelPreviewProps> = ({
         borderColor={borderColor}
         canvasSize={canvasSize}
         offset={getCanvasOffset()}
+        position={
+          gamePosition === 'left'
+            ? 'gauche'
+            : gamePosition === 'right'
+            ? 'droite'
+            : gamePosition === 'bottom'
+            ? 'bas'
+            : 'centre'
+        }
       />
       
       <WheelDecorations
@@ -119,7 +137,7 @@ const MobileWheelPreview: React.FC<MobileWheelPreviewProps> = ({
       <WheelPointer
         pointerColor={pointerColor}
         gamePosition={gamePosition}
-        containerWidth={shouldCropWheel ? canvasSize / 2 : canvasSize}
+        containerWidth={containerWidth}
         canvasSize={canvasSize}
         shouldCropWheel={shouldCropWheel}
       />

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -74,7 +74,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   const isCroppablePosition = ['left', 'right', 'bottom'].includes(gamePosition);
   const shouldCropWheel = isMobile && isCroppablePosition;
   
-  const { canvasSize, containerWidth, pointerSize } = getWheelDimensions(
+  const { canvasSize, containerWidth, containerHeight, pointerSize } = getWheelDimensions(
     gameDimensions,
     gamePosition,
     shouldCropWheel
@@ -143,8 +143,8 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
     >
       <div style={{ 
         position: 'relative', 
-        width: containerWidth, 
-        height: canvasSize,
+        width: containerWidth,
+        height: containerHeight,
         overflow: shouldCropWheel ? 'hidden' : 'visible'
       }}>
         {/* Ombre réduite */}
@@ -179,7 +179,11 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
             borderColor={borderColor}
             borderOutlineColor={borderOutlineColor}
             canvasSize={canvasSize}
-            offset={shouldCropWheel && gamePosition === 'right' ? `-${canvasSize * 0.5}px` : '0px'}
+            offset={
+              shouldCropWheel && gamePosition === 'left'
+                ? `-${canvasSize * 0.5}px`
+                : '0px'
+            }
             position={position}
           />
           

--- a/src/utils/wheelConfig.ts
+++ b/src/utils/wheelConfig.ts
@@ -30,8 +30,11 @@ export const getWheelDimensions = (
     shouldCropWheel && (gamePosition === 'left' || gamePosition === 'right')
       ? baseCanvasSize * 0.5
       : baseCanvasSize;
-  
+
+  const containerHeight =
+    shouldCropWheel && gamePosition === 'bottom' ? baseCanvasSize * 0.5 : baseCanvasSize;
+
   const pointerSize = Math.max(30, canvasSize * 0.08);
 
-  return { canvasSize, containerWidth, pointerSize };
+  return { canvasSize, containerWidth, containerHeight, pointerSize };
 };


### PR DESCRIPTION
## Summary
- keep mobile wheel container to exactly half width
- fix canvas offset for left position
- add strict half clipping for bottom mobile wheel
- document setup and build steps for using vite

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842fa11a090832a8abebcf83a6902f2