### PR TITLE
Show card count for scratch preview

### DIFF
--- a/src/components/GameTypes/ScratchPreview.tsx
+++ b/src/components/GameTypes/ScratchPreview.tsx
@@ -74,6 +74,7 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
   };
 
   const { width, height } = getDimensions();
+  const totalCards = Array.isArray(config.cards) ? config.cards.length : 1;
 
   useEffect(() => {
     const card = config?.cards ? config.cards[currentCard] || {} : {};
@@ -221,7 +222,7 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
   if (!gameStarted) {
     return (
       <div className="flex flex-col items-center space-y-4">
-        <div 
+        <div
           className="relative rounded-lg overflow-hidden border-2 border-gray-300"
           style={{ width: `${width}px`, height: `${height}px` }}
         >
@@ -230,14 +231,19 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
               <div className="text-2xl mb-2">🎫</div>
               <div className="text-sm">Carte à gratter</div>
             </div>
+            {totalCards > 1 && (
+              <div className="absolute top-2 right-2 text-xs bg-black/60 text-white px-2 py-1 rounded">
+                {currentCard + 1}/{totalCards}
+              </div>
+            )}
           </div>
         </div>
-        
+
         <button
           onClick={handleGameStart}
           disabled={disabled}
           className="px-6 py-3 rounded-lg font-semibold text-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90"
-          style={{ 
+          style={{
             backgroundColor: disabled ? '#6b7280' : buttonColor
           }}
         >
@@ -251,6 +257,11 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
     <div className="w-full flex flex-col items-center space-y-4">
       {gameStarted && !isRevealed && (
         <div className="text-center">
+          {totalCards > 1 && (
+            <div className="text-xs text-gray-500 mb-1">
+              Carte {currentCard + 1}/{totalCards}
+            </div>
+          )}
           <div className="text-sm text-gray-600 mb-2">
             Progression: {scratchPercentage}% / {config?.scratchArea || 70}%
           </div>
@@ -294,6 +305,11 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
                   ? (config?.cards ? (config.cards[currentCard]?.revealMessage || config?.revealMessage) : config?.revealMessage) || 'Vous avez gagné !'
                   : 'Réessayez !'}
               </p>
+              {totalCards > 1 && (
+                <p className="text-xs text-gray-500 mb-2">
+                  Carte {currentCard + 1}/{totalCards}
+                </p>
+              )}
               <button
                 onClick={resetGame}
                 className="px-4 py-2 bg-[#841b60] text-white rounded hover:bg-[#6d1650] transition-colors"

--- a/src/utils/campaignTypes.tsx
+++ b/src/utils/campaignTypes.tsx
@@ -1,3 +1,4 @@
+
 import { 
   Target, 
   Users, 
@@ -68,3 +69,175 @@ interface ScratchCard {
   revealImage: string;
   revealMessage: string;
 }
+
+interface MemoryConfig extends BaseConfig {
+  pairs: number;
+  difficulty: string;
+  timeLimit: number;
+}
+
+interface PuzzleConfig extends BaseConfig {
+  pieces: number;
+  timeLimit: number;
+}
+
+interface QuizConfig extends BaseConfig {
+  questions: any[];
+  timePerQuestion: number;
+}
+
+interface DiceConfig extends BaseConfig {
+  diceCount: number;
+  winningConditions: number[];
+}
+
+interface SwiperConfig extends BaseConfig {
+  direction: string;
+}
+
+interface FormConfig extends BaseConfig { }
+
+interface InstantWinConfig {
+  mode: "instant_winner";
+  winProbability: number;
+  maxWinners?: number;
+  winnersCount?: number;
+}
+
+export const getDefaultGameConfig = (type: CampaignType) => {
+  const configs = {
+    wheel: {
+      winProbability: 0.1,
+      maxWinners: 10,
+      winnersCount: 0,
+      buttonLabel: 'Tourner',
+      buttonColor: '#841b60'
+    },
+    jackpot: {
+      instantWin: {
+        mode: 'instant_winner' as const,
+        winProbability: 0.05,
+        maxWinners: 10,
+        winnersCount: 0
+      },
+      buttonLabel: 'Lancer le Jackpot',
+      buttonColor: '#841b60',
+      containerBackgroundColor: '#1f2937',
+      backgroundColor: '#c4b5fd30',
+      borderColor: '#8b5cf6',
+      borderWidth: 3,
+      slotBorderColor: '#a78bfa',
+      slotBorderWidth: 2,
+      slotBackgroundColor: '#ffffff'
+    },
+    scratch: {
+      instantWin: {
+        mode: 'instant_winner' as const,
+        winProbability: 0.1,
+        maxWinners: 10,
+        winnersCount: 0
+      },
+      scratchArea: 70,
+      revealMessage: 'Félicitations !',
+      cards: [
+        { id: 1, revealImage: '', revealMessage: 'Félicitations !' }
+      ],
+      buttonLabel: 'Gratter',
+      buttonColor: '#841b60'
+    },
+    memory: {
+      pairs: 8,
+      difficulty: 'medium',
+      timeLimit: 60,
+      buttonLabel: 'Commencer',
+      buttonColor: '#841b60'
+    },
+    puzzle: {
+      pieces: 9,
+      timeLimit: 300,
+      buttonLabel: 'Commencer',
+      buttonColor: '#841b60'
+    },
+    quiz: {
+      questions: [],
+      timePerQuestion: 30,
+      buttonLabel: 'Commencer',
+      buttonColor: '#841b60'
+    },
+    dice: {
+      diceCount: 2,
+      winningConditions: [7, 11],
+      buttonLabel: 'Lancer les dés',
+      buttonColor: '#841b60'
+    },
+    swiper: {
+      direction: 'horizontal',
+      buttonLabel: 'Swiper',
+      buttonColor: '#841b60'
+    },
+    form: {
+      buttonLabel: 'Valider',
+      buttonColor: '#841b60'
+    }
+  };
+
+  return configs[type] || {};
+};
+
+export const getCampaignTypeIcon = (type: string) => {
+  switch (type) {
+    case 'wheel':
+      return Target;
+    case 'jackpot':
+      return DollarSign;
+    case 'memory':
+      return Brain;
+    case 'puzzle':
+      return Puzzle;
+    case 'quiz':
+      return HelpCircle;
+    case 'dice':
+      return Dice6;
+    case 'scratch':
+      return Cookie;
+    case 'swiper':
+      return ArrowRight;
+    case 'form':
+      return FileText;
+    case 'contest':
+      return Target;
+    case 'survey':
+      return Users;
+    default:
+      return HelpCircle;
+  }
+};
+
+export const getCampaignTypeText = (type: string) => {
+  switch (type) {
+    case 'wheel':
+      return 'Roue';
+    case 'jackpot':
+      return 'Jackpot';
+    case 'memory':
+      return 'Memory';
+    case 'puzzle':
+      return 'Puzzle';
+    case 'quiz':
+      return 'Quiz';
+    case 'dice':
+      return 'Dés';
+    case 'scratch':
+      return 'Grattage';
+    case 'swiper':
+      return 'Swiper';
+    case 'form':
+      return 'Formulaire';
+    case 'contest':
+      return 'Concours';
+    case 'survey':
+      return 'Sondage';
+    default:
+      return 'Jeu';
+  }
+};


### PR DESCRIPTION
## Summary
- display number of scratch cards in ScratchPreview
- show current card index in progress and result states
- restore full campaignTypes utilities with missing exports

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843553fed84832abd813662c657cb9d