### PR TITLE
Adjust card grid layout for responsiveness

### DIFF
--- a/src/components/QuickCampaign/ColorCustomizer.tsx
+++ b/src/components/QuickCampaign/ColorCustomizer.tsx
@@ -227,7 +227,7 @@ const ColorCustomizer: React.FC = () => {
       </div>
 
       {/* Palettes prédéfinies */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         {colorPalettes.map(palette => (
           <div 
             key={palette.id}

--- a/src/components/QuickCampaign/Step1GameSelection.tsx
+++ b/src/components/QuickCampaign/Step1GameSelection.tsx
@@ -89,7 +89,7 @@ const Step1GameSelection: React.FC = () => {
           </div>
 
           {/* Game Selection Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-16">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mb-16">
             {gameTypes.map((game, index) => {
               const IconComponent = game.icon;
               const isSelected = selectedGameType === game.id;

--- a/src/index.css
+++ b/src/index.css
@@ -173,7 +173,7 @@ textarea {
 
 /* Card layouts */
 .card-grid {
-  @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6;
+  @apply grid grid-cols-2 md:grid-cols-3 gap-6;
 }
 
 /* Styles pour le slider de segments */

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -110,7 +110,7 @@ const Dashboard: React.FC = () => {
           </Link>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mt-6">
           {stats.map((stat, index) => <div key={index} className="bg-white p-6 rounded-2xl shadow-md flex justify-between items-start">
               <div>
                 <p className="text-gray-700 font-semibold">{stat.name}</p>
@@ -135,7 +135,7 @@ const Dashboard: React.FC = () => {
               </Link>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
               {recentCampaigns.map(campaign => {
               const IconComponent = getCampaignTypeIcon(campaign.type);
               return <div key={campaign.id} className="bg-white rounded-xl shadow hover:shadow-md transition-all duration-300 overflow-hidden">

--- a/src/pages/Data.tsx
+++ b/src/pages/Data.tsx
@@ -79,7 +79,7 @@ const Data: React.FC = () => {
               </div>
             </div>
             
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
               <div className="border border-gray-200 rounded-lg p-4">
                 <h3 className="text-sm font-medium text-gray-600 mb-2">Top 10 réponses</h3>
                 <div className="h-48 flex items-center justify-center bg-gray-50 rounded">

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -97,7 +97,7 @@ const Gamification: React.FC = () => {
             </p>
           </div>
           
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
             {gamificationTypes.map((game, index) => (
               <div key={index} className="border border-gray-200 rounded-xl overflow-hidden hover:shadow-md transition-shadow duration-300">
                 <div className="h-24 flex items-center justify-center" style={{ backgroundColor: game.color }}>

--- a/src/pages/Social.tsx
+++ b/src/pages/Social.tsx
@@ -24,7 +24,7 @@ const Social: React.FC = () => {
       </div>
 
       <div className="px-6 space-y-6">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mt-6">
           <div className="lg:col-span-2 space-y-6">
             <div className="bg-white rounded-xl shadow-sm p-6">
               <h2 className="text-lg font-bold text-gray-800 mb-4">Publications</h2>

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -34,7 +34,7 @@ const Statistics: React.FC = () => {
       </div>
 
       <div className="px-6 space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mt-6">
           <div className="bg-white p-6 rounded-xl shadow-sm">
             <div className="flex justify-between items-start">
               <div>
@@ -88,7 +88,7 @@ const Statistics: React.FC = () => {
           </div>
         </div>
         
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
           <div className="bg-white p-6 rounded-xl shadow-sm lg:col-span-2">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-lg font-bold text-gray-800">Évolution des participations</h2>

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -45,7 +45,7 @@ const Studies: React.FC = () => {
       </div>
 
       <div className="px-6 space-y-6">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mt-6">
           <div className="lg:col-span-2 space-y-6">
             <div className="bg-white rounded-xl shadow-sm p-6">
               <h2 className="text-lg font-bold text-gray-800 mb-4">Publication hebdomadaire</h2>


### PR DESCRIPTION
## Summary
- tweak card grid styles for consistent responsive behavior across pages
- show 2 cards per row on mobile, 3 per row on larger screens

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684359d2b594832a9998abf227b05fbf