### PR TITLE
Fix scratch card spacing in modern previews

### DIFF
--- a/src/components/GameTypes/ScratchGameGrid.tsx
+++ b/src/components/GameTypes/ScratchGameGrid.tsx
@@ -20,9 +20,9 @@ const ScratchGameGrid: React.FC<ScratchGameGridProps> = ({
   const gridClasses =
     cards.length === 1
       ?
-        'grid grid-cols-1 justify-center place-items-center'
+        'grid grid-cols-1 gap-4 justify-center place-items-center'
       :
-        'grid grid-cols-2 md:grid-cols-3 gap-4 md:gap-6 justify-items-center';
+        'grid grid-cols-2 md:grid-cols-3 gap-6 md:gap-8 justify-items-center';
 
   return (
     <div className="w-full max-w-4xl mx-auto px-6">


### PR DESCRIPTION
## Summary
- tweak grid spacing of scratch card preview grid
- update dependencies to build successfully

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684386af9fc4832a9a502dbf4768d481