### PR TITLE
Add spacing between scratch cards

### DIFF
--- a/src/components/GameTypes/ScratchGameGrid.tsx
+++ b/src/components/GameTypes/ScratchGameGrid.tsx
@@ -23,9 +23,10 @@ const ScratchGameGrid: React.FC<ScratchGameGridProps> = ({
     : 'grid grid-cols-2 md:grid-cols-3 justify-items-center';
 
   // Spacing based on number of cards and screen size
+  // Ajout d'un espacement plus généreux entre les cartes
   const spacingClasses = cards.length === 1
     ? 'gap-0'
-    : 'gap-4 md:gap-6';
+    : 'gap-6 md:gap-8';
 
   return (
     <div className="w-full max-w-6xl mx-auto px-4">


### PR DESCRIPTION
## Summary
- adjust spacing for scratch cards so there's more room between them

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68440723d2e0832a8aa35fc320a46654