### PR TITLE
Fix scratch card preview layout

### DIFF
--- a/src/components/GameTypes/ScratchCard.tsx
+++ b/src/components/GameTypes/ScratchCard.tsx
@@ -181,9 +181,9 @@ const ScratchCard: React.FC<ScratchCardProps> = ({
   if (!gameStarted) {
     return (
       <div className="flex flex-col items-center">
-        <div 
-          className="relative rounded-lg overflow-hidden border-2 border-gray-300 mb-2" 
-          style={{ width: `${width}px`, height: `${height}px` }}
+        <div
+          className="relative rounded-lg overflow-hidden border-2 border-gray-300 mb-2"
+          style={{ width: '100%', maxWidth: `${width}px`, height: `${height}px` }}
         >
           <div className="absolute inset-0 bg-gradient-to-br from-gray-400 to-gray-600 flex items-center justify-center">
             <div className="text-white text-center">
@@ -214,7 +214,7 @@ const ScratchCard: React.FC<ScratchCardProps> = ({
 
       <div 
         className="relative rounded-lg overflow-hidden border-2 border-gray-300" 
-        style={{ width: `${width}px`, height: `${height}px` }}
+        style={{ width: '100%', maxWidth: `${width}px`, height: `${height}px` }}
       >
         {/* Contenu à révéler */}
         <div className="absolute inset-0">

--- a/src/components/GameTypes/ScratchGameGrid.tsx
+++ b/src/components/GameTypes/ScratchGameGrid.tsx
@@ -17,16 +17,18 @@ const ScratchGameGrid: React.FC<ScratchGameGridProps> = ({
   onCardFinish,
   config
 }) => {
-  // Responsive grid: 2 cards max on mobile, 3 on tablet/desktop
-  const gridClasses = cards.length === 1
-    ? 'grid grid-cols-1 justify-items-center'
-    : 'grid grid-cols-2 md:grid-cols-3 justify-items-center';
+  // Responsive grid: 2 cards on mobile, 3 on tablet/desktop
+  const columnClasses = cards.length === 1
+    ? 'grid-cols-1'
+    : 'grid-cols-2 md:grid-cols-3';
 
-  // Spacing based on number of cards and screen size
-  // Ajout d'un espacement plus généreux entre les cartes
+  // Center the grid when there is a single card
+  const gridClasses = `grid ${columnClasses} justify-center`;
+
+  // Consistent spacing between cards
   const spacingClasses = cards.length === 1
-    ? 'gap-0'
-    : 'gap-6 md:gap-8';
+    ? 'gap-y-6'
+    : 'gap-4 md:gap-6';
 
   return (
     <div className="w-full max-w-6xl mx-auto px-4">


### PR DESCRIPTION
## Summary
- keep scratch cards responsive
- adjust grid layout and spacing for mobile/desktop breakpoints

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684411520bc4832a836340876930bbbe