### PR TITLE
Fix scratch preview

### DIFF
--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -94,6 +94,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             buttonLabel={buttonLabel}
             buttonColor={buttonColor}
             gameSize={gameSize}
+            autoStart
           />
         </div>
       );

--- a/src/components/GameTypes/ScratchPreview.tsx
+++ b/src/components/GameTypes/ScratchPreview.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ScratchGameGrid from './ScratchGameGrid';
 
 interface ScratchPreviewProps {
@@ -11,6 +11,12 @@ interface ScratchPreviewProps {
   buttonColor?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
+  /**
+   * When true, the game starts immediately without requiring the user to
+   * click the start button. Useful for preview mode where we want to display
+   * the interactive game directly.
+   */
+  autoStart?: boolean;
 }
 
 const ScratchPreview: React.FC<ScratchPreviewProps> = ({
@@ -20,11 +26,20 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
   disabled = false,
   buttonLabel = 'Gratter',
   buttonColor = '#841b60',
-  gameSize = 'medium'
+  gameSize = 'medium',
+  autoStart = false
 }) => {
-  const [gameStarted, setGameStarted] = useState(false);
+  const [gameStarted, setGameStarted] = useState(autoStart && !disabled);
   const [finishedCards, setFinishedCards] = useState<Set<number>>(new Set());
   const [hasWon, setHasWon] = useState(false);
+
+  // Automatically start the game in preview mode if autoStart is enabled
+  useEffect(() => {
+    if (autoStart && !gameStarted && !disabled) {
+      setGameStarted(true);
+      if (onStart) onStart();
+    }
+  }, [autoStart, gameStarted, disabled, onStart]);
 
   const handleGameStart = () => {
     if (disabled) return;

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -107,8 +107,9 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'scratch':
       return (
-        <ScratchPreview 
+        <ScratchPreview
           config={mockCampaign.gameConfig?.scratch || {}}
+          autoStart
         />
       );
 


### PR DESCRIPTION
## Summary
- start scratch game automatically in preview
- enable autoStart in preview GameRenderer components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684413999568832a928f36440af2b2b9