### PR TITLE
Fix scratch preview

### DIFF
--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -94,6 +94,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             buttonLabel={buttonLabel}
             buttonColor={buttonColor}
             gameSize={gameSize}
+            autoStart
           />
         </div>
       );

--- a/src/components/GameTypes/ScratchPreview.tsx
+++ b/src/components/GameTypes/ScratchPreview.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ScratchGameGrid from './ScratchGameGrid';
 
 interface ScratchPreviewProps {
@@ -11,6 +11,12 @@ interface ScratchPreviewProps {
   buttonColor?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
+  /**
+   * When true, the game starts immediately without requiring the user to
+   * click the start button. Useful for preview mode where we want to display
+   * the interactive game directly.
+   */
+  autoStart?: boolean;
 }
 
 const ScratchPreview: React.FC<ScratchPreviewProps> = ({
@@ -20,11 +26,20 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
   disabled = false,
   buttonLabel = 'Gratter',
   buttonColor = '#841b60',
-  gameSize = 'medium'
+  gameSize = 'medium',
+  autoStart = false
 }) => {
-  const [gameStarted, setGameStarted] = useState(false);
+  const [gameStarted, setGameStarted] = useState(autoStart && !disabled);
   const [finishedCards, setFinishedCards] = useState<Set<number>>(new Set());
   const [hasWon, setHasWon] = useState(false);
+
+  // Automatically start the game in preview mode if autoStart is enabled
+  useEffect(() => {
+    if (autoStart && !gameStarted && !disabled) {
+      setGameStarted(true);
+      if (onStart) onStart();
+    }
+  }, [autoStart, gameStarted, disabled, onStart]);
 
   const handleGameStart = () => {
     if (disabled) return;

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchCardsManager.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchCardsManager.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchCardsManagerProps {
   cards: any[];
@@ -61,33 +62,11 @@ const ScratchCardsManager: React.FC<ScratchCardsManagerProps> = ({
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700">Image spécifique</label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) {
-                  const url = URL.createObjectURL(file);
-                  onUpdateCard(index, 'revealImage', url);
-                }
-              }}
-              className="w-full"
+            <ImageUpload
+              value={card.revealImage || ''}
+              onChange={(value) => onUpdateCard(index, 'revealImage', value)}
+              label=""
             />
-            {card.revealImage && (
-              <div className="mt-2">
-                <img 
-                  src={card.revealImage} 
-                  alt="Aperçu" 
-                  className="w-full h-20 object-cover rounded border" 
-                />
-                <button
-                  onClick={() => onUpdateCard(index, 'revealImage', '')}
-                  className="mt-1 text-xs text-red-600 hover:text-red-800"
-                >
-                  Supprimer
-                </button>
-              </div>
-            )}
           </div>
         </div>
       ))}

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchRevealConfig.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchRevealConfig.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Percent, Type, Image } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchRevealConfigProps {
   scratchArea: number;
@@ -61,33 +62,7 @@ const ScratchRevealConfig: React.FC<ScratchRevealConfigProps> = ({
           <Image className="w-4 h-4 mr-2" />
           Image de révélation par défaut (optionnel)
         </label>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const url = URL.createObjectURL(file);
-              onRevealImageChange(url);
-            }
-          }}
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#841b60] focus:border-transparent"
-        />
-        {revealImage && (
-          <div className="mt-2">
-            <img
-              src={revealImage}
-              alt="Aperçu"
-              className="w-full h-20 object-cover rounded border"
-            />
-            <button
-              onClick={() => onRevealImageChange('')}
-              className="mt-1 text-xs text-red-600 hover:text-red-800"
-            >
-              Supprimer
-            </button>
-          </div>
-        )}
+        <ImageUpload value={revealImage || ''} onChange={onRevealImageChange} label="" />
       </div>
     </>
   );

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchSurfaceConfig.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchSurfaceConfig.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Palette } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchSurfaceConfigProps {
   scratchColor: string;
@@ -39,36 +40,16 @@ const ScratchSurfaceConfig: React.FC<ScratchSurfaceConfigProps> = ({
       {/* Surface à gratter personnalisée */}
       <div className="space-y-2">
         <label className="text-sm font-medium text-gray-700">Surface à gratter personnalisée</label>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const url = URL.createObjectURL(file);
-              onScratchSurfaceChange(url);
-            }
-          }}
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#841b60] focus:border-transparent"
+        <ImageUpload
+          value={scratchSurface || ''}
+          onChange={onScratchSurfaceChange}
+          label=""
         />
         {scratchSurface && (
-          <div className="mt-2">
-            <img
-              src={scratchSurface}
-              alt="Surface à gratter"
-              className="w-full h-20 object-cover rounded border"
-            />
-            <button
-              onClick={() => onScratchSurfaceChange('')}
-              className="mt-1 text-xs text-red-600 hover:text-red-800"
-            >
-              Supprimer
-            </button>
-          </div>
+          <p className="text-xs text-gray-500">
+            Image utilisée comme surface à gratter
+          </p>
         )}
-        <p className="text-xs text-gray-500">
-          Image qui sera utilisée comme surface à gratter (par défaut: couleur métallique)
-        </p>
       </div>
     </>
   );

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -107,8 +107,9 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'scratch':
       return (
-        <ScratchPreview 
+        <ScratchPreview
           config={mockCampaign.gameConfig?.scratch || {}}
+          autoStart
         />
       );
 


### PR DESCRIPTION
## Summary
- start scratch game automatically in preview
- enable autoStart in preview GameRenderer components
- improve scratch campaign editors by using ImageUpload components for all images so uploads work correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684413999568832a928f36440af2b2b9