### PR TITLE
Fix scratch preview

### DIFF
--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -94,6 +94,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             buttonLabel={buttonLabel}
             buttonColor={buttonColor}
             gameSize={gameSize}
+            autoStart
           />
         </div>
       );

--- a/src/components/GameTypes/ScratchPreview.tsx
+++ b/src/components/GameTypes/ScratchPreview.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ScratchGameGrid from './ScratchGameGrid';
 
 interface ScratchPreviewProps {
@@ -11,6 +11,12 @@ interface ScratchPreviewProps {
   buttonColor?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
+  /**
+   * When true, the game starts immediately without requiring the user to
+   * click the start button. Useful for preview mode where we want to display
+   * the interactive game directly.
+   */
+  autoStart?: boolean;
 }
 
 const ScratchPreview: React.FC<ScratchPreviewProps> = ({
@@ -20,11 +26,20 @@ const ScratchPreview: React.FC<ScratchPreviewProps> = ({
   disabled = false,
   buttonLabel = 'Gratter',
   buttonColor = '#841b60',
-  gameSize = 'medium'
+  gameSize = 'medium',
+  autoStart = false
 }) => {
-  const [gameStarted, setGameStarted] = useState(false);
+  const [gameStarted, setGameStarted] = useState(autoStart && !disabled);
   const [finishedCards, setFinishedCards] = useState<Set<number>>(new Set());
   const [hasWon, setHasWon] = useState(false);
+
+  // Automatically start the game in preview mode if autoStart is enabled
+  useEffect(() => {
+    if (autoStart && !gameStarted && !disabled) {
+      setGameStarted(true);
+      if (onStart) onStart();
+    }
+  }, [autoStart, gameStarted, disabled, onStart]);
 
   const handleGameStart = () => {
     if (disabled) return;

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchCardsManager.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchCardsManager.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchCardsManagerProps {
   cards: any[];
@@ -61,33 +62,11 @@ const ScratchCardsManager: React.FC<ScratchCardsManagerProps> = ({
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-gray-700">Image spécifique</label>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) {
-                  const url = URL.createObjectURL(file);
-                  onUpdateCard(index, 'revealImage', url);
-                }
-              }}
-              className="w-full"
+            <ImageUpload
+              value={card.revealImage || ''}
+              onChange={(value) => onUpdateCard(index, 'revealImage', value)}
+              label=""
             />
-            {card.revealImage && (
-              <div className="mt-2">
-                <img 
-                  src={card.revealImage} 
-                  alt="Aperçu" 
-                  className="w-full h-20 object-cover rounded border" 
-                />
-                <button
-                  onClick={() => onUpdateCard(index, 'revealImage', '')}
-                  className="mt-1 text-xs text-red-600 hover:text-red-800"
-                >
-                  Supprimer
-                </button>
-              </div>
-            )}
           </div>
         </div>
       ))}

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchRevealConfig.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchRevealConfig.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Percent, Type, Image } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchRevealConfigProps {
   scratchArea: number;
@@ -61,33 +62,7 @@ const ScratchRevealConfig: React.FC<ScratchRevealConfigProps> = ({
           <Image className="w-4 h-4 mr-2" />
           Image de révélation par défaut (optionnel)
         </label>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const url = URL.createObjectURL(file);
-              onRevealImageChange(url);
-            }
-          }}
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#841b60] focus:border-transparent"
-        />
-        {revealImage && (
-          <div className="mt-2">
-            <img
-              src={revealImage}
-              alt="Aperçu"
-              className="w-full h-20 object-cover rounded border"
-            />
-            <button
-              onClick={() => onRevealImageChange('')}
-              className="mt-1 text-xs text-red-600 hover:text-red-800"
-            >
-              Supprimer
-            </button>
-          </div>
-        )}
+        <ImageUpload value={revealImage || ''} onChange={onRevealImageChange} label="" />
       </div>
     </>
   );

--- a/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchSurfaceConfig.tsx
+++ b/src/components/ModernEditor/GameConfigs/ScratchConfig/ScratchSurfaceConfig.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Palette } from 'lucide-react';
+import ImageUpload from '../../../common/ImageUpload';
 
 interface ScratchSurfaceConfigProps {
   scratchColor: string;
@@ -39,36 +40,16 @@ const ScratchSurfaceConfig: React.FC<ScratchSurfaceConfigProps> = ({
       {/* Surface à gratter personnalisée */}
       <div className="space-y-2">
         <label className="text-sm font-medium text-gray-700">Surface à gratter personnalisée</label>
-        <input
-          type="file"
-          accept="image/*"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const url = URL.createObjectURL(file);
-              onScratchSurfaceChange(url);
-            }
-          }}
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#841b60] focus:border-transparent"
+        <ImageUpload
+          value={scratchSurface || ''}
+          onChange={onScratchSurfaceChange}
+          label=""
         />
         {scratchSurface && (
-          <div className="mt-2">
-            <img
-              src={scratchSurface}
-              alt="Surface à gratter"
-              className="w-full h-20 object-cover rounded border"
-            />
-            <button
-              onClick={() => onScratchSurfaceChange('')}
-              className="mt-1 text-xs text-red-600 hover:text-red-800"
-            >
-              Supprimer
-            </button>
-          </div>
+          <p className="text-xs text-gray-500">
+            Image utilisée comme surface à gratter
+          </p>
         )}
-        <p className="text-xs text-gray-500">
-          Image qui sera utilisée comme surface à gratter (par défaut: couleur métallique)
-        </p>
       </div>
     </>
   );

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -1,6 +1,8 @@
 
 import React, { useState } from 'react';
 import { X, Monitor, Smartphone, Tablet } from 'lucide-react';
+import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
+import FunnelStandard from '../funnels/FunnelStandard';
 
 interface ModernPreviewModalProps {
   isOpen: boolean;
@@ -28,9 +30,75 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
     }
   };
 
+  const getContainerStyle = () => {
+    const baseStyle = {
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: campaign.design?.background || '#f9fafb',
+      position: 'relative' as const,
+      overflow: 'hidden' as const
+    } as React.CSSProperties;
+
+    if (campaign.design?.backgroundImage) {
+      return {
+        ...baseStyle,
+        backgroundImage: `url(${campaign.design.backgroundImage})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat'
+      };
+    }
+    return baseStyle;
+  };
+
+  const enhancedCampaign = {
+    ...campaign,
+    design: {
+      ...campaign.design,
+      buttonColor:
+        campaign.buttonConfig?.color || campaign.design?.buttonColor || '#841b60',
+      titleColor: campaign.design?.titleColor || '#000000',
+      background: campaign.design?.background || '#f8fafc'
+    },
+    gameConfig: {
+      ...campaign.gameConfig,
+      [campaign.type]: {
+        ...campaign.gameConfig?.[campaign.type],
+        buttonLabel:
+          campaign.buttonConfig?.text ||
+          campaign.gameConfig?.[campaign.type]?.buttonLabel ||
+          'Jouer',
+        buttonColor:
+          campaign.buttonConfig?.color ||
+          campaign.gameConfig?.[campaign.type]?.buttonColor ||
+          '#841b60'
+      }
+    }
+  };
+
+  const getFunnelComponent = () => {
+    const unlockedTypes = ['wheel', 'scratch', 'jackpot', 'dice'];
+    const funnel =
+      enhancedCampaign.funnel ||
+      (unlockedTypes.includes(enhancedCampaign.type) ? 'unlocked_game' : 'standard');
+    if (funnel === 'unlocked_game') {
+      return (
+        <FunnelUnlockedGame
+          campaign={enhancedCampaign}
+          previewMode={device === 'desktop' ? 'desktop' : device}
+          modalContained={false}
+        />
+      );
+    }
+    return <FunnelStandard campaign={enhancedCampaign} />;
+  };
+
   return (
-    <div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-[95vw] max-h-[95vh] flex flex-col">
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className="bg-white w-full h-full flex flex-col relative overflow-hidden rounded-3xl shadow-2xl max-w-7xl max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b">
           <div className="flex items-center space-x-4">
@@ -71,41 +139,18 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
         </div>
 
         {/* Preview Content */}
-        <div className="flex-1 p-8 bg-gray-100 flex items-center justify-center">
-          <div
-            className="bg-white rounded-lg shadow-lg overflow-hidden"
-            style={getDeviceStyles()}
-          >
-            <div
-              className="h-full p-6 flex flex-col items-center justify-center"
-              style={{
-                backgroundColor: campaign.design?.background || '#f8fafc',
-                fontFamily: campaign.design?.fontFamily || 'Inter'
-              }}
-            >
-              <div className="text-center space-y-4">
-                <h1
-                  className="text-3xl font-bold"
-                  style={{ color: campaign.design?.titleColor || '#000000' }}
+        <div className="flex-1 pt-20 overflow-auto">
+          <div className="w-full h-full flex items-center justify-center p-4">
+            <div style={getDeviceStyles()}>
+              <div style={getContainerStyle()}>
+                {campaign.design?.backgroundImage && (
+                  <div className="absolute inset-0 bg-black opacity-20" style={{ zIndex: 1 }} />
+                )}
+                <div
+                  className="relative z-10 w-full h-full flex items-center justify-center p-4"
+                  style={{ minHeight: device === 'desktop' ? '600px' : '100%' }}
                 >
-                  {campaign.screens?.[1]?.title || 'Bienvenue !'}
-                </h1>
-                <p className="text-lg text-gray-600">
-                  {campaign.screens?.[1]?.description || 'Participez à notre jeu et tentez de gagner !'}
-                </p>
-                <button
-                  className="px-8 py-3 rounded-lg text-white font-medium text-lg"
-                  style={{ backgroundColor: campaign.design?.buttonColor || '#841b60' }}
-                >
-                  {campaign.screens?.[1]?.buttonText || 'Participer'}
-                </button>
-              </div>
-
-              {/* Game Preview Area */}
-              <div className="mt-8 p-6 border-2 border-dashed border-gray-300 rounded-lg">
-                <div className="text-center text-gray-500">
-                  <div className="text-lg font-medium">Jeu : {campaign.type}</div>
-                  <div className="text-sm mt-2">Position : {campaign.gamePosition || 'center'}</div>
+                  {getFunnelComponent()}
                 </div>
               </div>
             </div>

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -107,8 +107,9 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'scratch':
       return (
-        <ScratchPreview 
+        <ScratchPreview
           config={mockCampaign.gameConfig?.scratch || {}}
+          autoStart
         />
       );
 


### PR DESCRIPTION
## Summary
- start scratch game automatically in preview
- enable autoStart in preview GameRenderer components
- improve scratch campaign editors by using ImageUpload components for all images so uploads work correctly
- ensure modern preview uses FunnelUnlockedGame so the complete flow displays correctly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684413999568832a928f36440af2b2b9