### PR TITLE
Fix scratch card grid responsiveness

### DIFF
--- a/src/components/GameTypes/ScratchCard.tsx
+++ b/src/components/GameTypes/ScratchCard.tsx
@@ -86,10 +86,11 @@ const ScratchCard: React.FC<ScratchCardProps> = ({
   if (!gameStarted) {
     return (
       <div className="flex flex-col items-center w-full max-w-xs mx-auto">
-        <div 
-          className="relative rounded-xl overflow-hidden border-2 border-gray-200 shadow-sm bg-white" 
+        <div
+          className="relative rounded-xl overflow-hidden border-2 border-gray-200 shadow-sm bg-white"
           style={{
-            width: `${width}px`,
+            width: '100%',
+            maxWidth: `${width}px`,
             height: `${height}px`
           }}
         >
@@ -129,7 +130,8 @@ const ScratchCard: React.FC<ScratchCardProps> = ({
               : 'border-gray-200'
         } ${locked ? 'opacity-50' : ''}`}
         style={{
-          width: `${width}px`,
+          width: '100%',
+          maxWidth: `${width}px`,
           height: `${height}px`,
           pointerEvents: locked ? 'none' : 'auto'
         }}

--- a/src/components/GameTypes/ScratchGameGrid.tsx
+++ b/src/components/GameTypes/ScratchGameGrid.tsx
@@ -32,7 +32,7 @@ const ScratchGameGrid: React.FC<ScratchGameGridProps> = ({
   // Configuration responsive de la grille
   const getGridConfig = () => {
     const cardCount = cards.length;
-    
+
     if (cardCount === 1) {
       return {
         containerClass: 'flex justify-center',
@@ -40,27 +40,27 @@ const ScratchGameGrid: React.FC<ScratchGameGridProps> = ({
         spacing: isModal ? 'gap-4' : 'gap-6'
       };
     }
-    
+
     if (cardCount === 2) {
       return {
-        containerClass: 'w-full',
-        gridClass: 'grid grid-cols-1 sm:grid-cols-2 place-items-center',
+        containerClass: 'w-full flex justify-center',
+        gridClass: 'grid grid-cols-2 place-items-center',
         spacing: isModal ? 'gap-4 sm:gap-6' : 'gap-6 sm:gap-8'
       };
     }
-    
+
     // Pour 3 cartes ou plus
     return {
-      containerClass: 'w-full',
-      gridClass: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 place-items-center',
-      spacing: isModal ? 'gap-4 sm:gap-5 lg:gap-4' : 'gap-6 sm:gap-8 lg:gap-6'
+      containerClass: 'w-full flex justify-center',
+      gridClass: 'grid grid-cols-2 md:grid-cols-3 place-items-center',
+      spacing: isModal ? 'gap-4 sm:gap-5 md:gap-6' : 'gap-6 sm:gap-8 md:gap-6'
     };
   };
 
   const { containerClass, gridClass, spacing } = getGridConfig();
 
   return (
-    <div className={`w-full mx-auto ${isModal ? 'max-w-4xl px-2 py-4' : 'max-w-6xl px-4 py-6'}`}>
+    <div className={`w-full mx-auto ${isModal ? 'max-w-4xl px-2 py-4' : 'max-w-6xl px-4 py-6'} overflow-x-hidden`}>
       <div className={containerClass}>
         <div className={`${gridClass} ${spacing} w-full`}>
           {cards.map((card: any, index: number) => {


### PR DESCRIPTION
## Summary
- adjust ScratchGameGrid for responsive layout with wrapping
- make scratch cards adapt to container width
- prevent horizontal overflow

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443e9c7ff4832a9ee521862291b8fc