### PR TITLE
Introduce toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-konva": "^18.2.10",
         "react-router-dom": "^6.11.1",
         "react-spring": "^9.7.3",
+        "react-toastify": "^9.1.3",
         "react-use": "^17.4.0",
         "resend": "^4.5.1",
         "rss-parser": "^3.13.0",
@@ -7331,6 +7332,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-universal-interface": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-konva": "^18.2.10",
     "react-router-dom": "^6.11.1",
     "react-spring": "^9.7.3",
+    "react-toastify": "^9.1.3",
     "react-use": "^17.4.0",
     "resend": "^4.5.1",
     "rss-parser": "^3.13.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { AppProvider } from './context/AppContext';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import Layout from './components/Layout/Layout';
 import Dashboard from './pages/Dashboard';
 import Campaigns from './pages/Campaigns';
@@ -34,8 +36,9 @@ function App() {
             <Route path="/data" element={<Layout><Data /></Layout>} />
             <Route path="/statistics" element={<Layout><Statistics /></Layout>} />
             <Route path="/studies" element={<Layout><Studies /></Layout>} />
-            <Route path="/account" element={<Layout><Account /></Layout>} />
-          </Routes>
+          <Route path="/account" element={<Layout><Account /></Layout>} />
+        </Routes>
+        <ToastContainer position="top-right" autoClose={3000} hideProgressBar />
         </div>
       </Router>
     </AppProvider>

--- a/src/components/Newsletter/properties/Tab/SettingsTab.tsx
+++ b/src/components/Newsletter/properties/Tab/SettingsTab.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Sparkles, Save, Eye } from 'lucide-react';
+import { toast } from 'react-toastify';
 import { useNewsletterStore } from '@/stores/newsletterStore';
 
 interface Template {
@@ -71,7 +72,7 @@ export const SettingsTab: React.FC = () => {
     if (!generatedContent) return;
     setFromGeneratedHTML(generatedContent);
     loadGeneratedAsModules();
-    alert('Le template a bien été transféré dans l\'onglet Modifier.');
+    toast.success("Le template a bien été transféré dans l'onglet Modifier.");
   };
 
   return (

--- a/src/components/funnels/FunnelUnlockedGame.tsx
+++ b/src/components/funnels/FunnelUnlockedGame.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { useParticipations } from '../../hooks/useParticipations';
+import { toast } from 'react-toastify';
 import GameRenderer from './components/GameRenderer';
 import ResultScreen from './components/ResultScreen';
 import FormHandler from './components/FormHandler';
@@ -75,7 +76,7 @@ const FunnelUnlockedGame: React.FC<FunnelUnlockedGameProps> = ({
       setTimeout(() => setShowValidationMessage(false), 2000);
     } catch (error) {
       console.error('Erreur lors de la soumission:', error);
-      alert('Erreur lors de la soumission du formulaire');
+      toast.error('Erreur lors de la soumission du formulaire');
     } finally {
       setParticipationLoading(false);
     }

--- a/src/hooks/useParticipations.ts
+++ b/src/hooks/useParticipations.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { supabase } from '../lib/supabase';
+import { toast } from 'react-toastify';
 
 export interface Participation {
   id: string;
@@ -104,7 +105,7 @@ export const useParticipations = () => {
 
   const exportParticipationsToCSV = (participations: Participation[], campaignName: string) => {
     if (participations.length === 0) {
-      alert('Aucune participation à exporter');
+      toast.info('Aucune participation à exporter');
       return;
     }
 


### PR DESCRIPTION
## Summary
- install and configure `react-toastify`
- add toast container in `App`
- replace `alert` usage with toast in newsletter settings and participations hook
- update funnel unlocked game to use toast on error

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844519b008c832ab5999e2e21fa8b79