### PR TITLE
Add typography settings

### DIFF
--- a/src/components/CampaignEditor/PreviewContent.tsx
+++ b/src/components/CampaignEditor/PreviewContent.tsx
@@ -41,22 +41,21 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ campaign, step = 'game'
   const getGameComponent = () => {
     if (isComplete) {
       return (
-        <div className="flex flex-col items-center justify-center text-center h-full w-full max-w-2xl mx-auto px-4">
-          <h2 
+          <div className="flex flex-col items-center justify-center text-center h-full w-full max-w-2xl mx-auto px-4">
+          <h2
             className="text-3xl font-bold mb-6"
-            style={{ 
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+            style={{
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[3].title || 'Félicitations !'}
           </h2>
           
-          <p 
+          <p
             className="text-xl"
-            style={{ 
-              color: getContrastColor(campaign.design.blockColor),
-              fontFamily: campaign.design.textFont
+            style={{
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || getContrastColor(campaign.design.blockColor)
             }}
           >
             {campaign.screens[3].description || 'Merci pour votre participation !'}

--- a/src/components/GameFunnel.tsx
+++ b/src/components/GameFunnel.tsx
@@ -55,8 +55,7 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <h2
             className="text-2xl font-bold mb-4"
             style={{
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[0]?.title || 'Ready to Play?'}
@@ -64,8 +63,8 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <p
             className="mb-6"
             style={{
-              color: getContrastColor(campaign.design.blockColor),
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || getContrastColor(campaign.design.blockColor)
             }}
           >
             {campaign.screens[0]?.description || 'Click below to participate'}
@@ -75,9 +74,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             className="px-8 py-3 font-medium transition-colors duration-200"
             style={{
               backgroundColor: campaign.design.buttonColor,
-              color: getContrastColor(campaign.design.buttonColor),
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
               borderRadius: campaign.design.borderRadius,
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.button
             }}
           >
             {campaign.screens[0]?.buttonText || 'Participate'}
@@ -90,8 +89,7 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <h2
             className="text-2xl font-bold mb-4"
             style={{
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[1]?.title || 'Your Information'}
@@ -141,14 +139,15 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             <button
               type="submit"
               className="w-full px-6 py-3 font-medium transition-colors mt-4"
-              style={{
-                backgroundColor: campaign.design.buttonColor,
-                color: getContrastColor(campaign.design.buttonColor),
-                borderRadius: campaign.design.borderRadius
-              }}
-            >
-              {campaign.screens[1]?.buttonText || 'Continue'}
-            </button>
+            style={{
+              backgroundColor: campaign.design.buttonColor,
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
+              borderRadius: campaign.design.borderRadius,
+              ...campaign.design.textStyles?.button
+            }}
+          >
+            {campaign.screens[1]?.buttonText || 'Continue'}
+          </button>
           </form>
         </div>
       )}
@@ -162,8 +161,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
               className="px-6 py-3"
               style={{
                 backgroundColor: campaign.design.buttonColor,
-                color: getContrastColor(campaign.design.buttonColor),
-                borderRadius: campaign.design.borderRadius
+                color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
+                borderRadius: campaign.design.borderRadius,
+                ...campaign.design.textStyles?.button
               }}
             >
               {campaign.screens[2]?.buttonText || 'Submit'}
@@ -186,8 +186,8 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <p
             className="mb-6"
             style={{
-              color: getContrastColor(campaign.design.blockColor),
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || getContrastColor(campaign.design.blockColor)
             }}
           >
             {campaign.screens[3]?.confirmationMessage || 'Your participation has been recorded.'}
@@ -197,8 +197,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             className="px-6 py-3 font-medium transition-colors duration-200 hover:opacity-90"
             style={{
               backgroundColor: campaign.design.buttonColor,
-              color: getContrastColor(campaign.design.buttonColor),
-              borderRadius: campaign.design.borderRadius
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
+              borderRadius: campaign.design.borderRadius,
+              ...campaign.design.textStyles?.button
             }}
           >
             {campaign.screens[3]?.replayButtonText || 'Play Again'}

--- a/src/components/GameTypes/FormPreview.tsx
+++ b/src/components/GameTypes/FormPreview.tsx
@@ -76,6 +76,10 @@ const FormPreview: React.FC<FormPreviewProps> = ({
         fields={fields}
         submitLabel={buttonLabel}
         onSubmit={handleFormSubmit}
+        textStyles={{
+          label: campaign.design.textStyles?.label,
+          button: campaign.design.textStyles?.button
+        }}
       />
     </div>
   );

--- a/src/components/GameTypes/WheelComponents/WheelFormModal.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelFormModal.tsx
@@ -32,6 +32,10 @@ const WheelFormModal: React.FC<WheelFormModalProps> = ({
         fields={fields}
         submitLabel={participationLoading ? 'Chargement...' : campaign.screens?.[1]?.buttonText || "C'est parti !"}
         onSubmit={onSubmit}
+        textStyles={{
+          label: campaign.design.textStyles?.label,
+          button: campaign.design.textStyles?.button
+        }}
       />
     </Modal>
   );

--- a/src/components/ModernEditor/ModernDesignTab.tsx
+++ b/src/components/ModernEditor/ModernDesignTab.tsx
@@ -122,6 +122,21 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
       }
     }));
   };
+  const handleTextStyleChange = (element: string, field: string, value: any) => {
+    setCampaign((prev: any) => ({
+      ...prev,
+      design: {
+        ...prev.design,
+        textStyles: {
+          ...prev.design.textStyles,
+          [element]: {
+            ...prev.design.textStyles?.[element],
+            [field]: value
+          }
+        }
+      }
+    }));
+  };
   const handleTextContentChange = (section: string, contentId: string, field: string, value: any) => {
     setCampaign((prev: any) => {
       const currentSection = prev.design?.[section] || {};
@@ -278,6 +293,62 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
       </div>
     </div>
   );
+  const renderTextStyleEditor = (key: string, style: any, title: string) => (
+    <div className="space-y-2 border-t pt-3">
+      <h4 className="text-sm font-medium text-gray-800">{title}</h4>
+      <div className="grid grid-cols-2 gap-2 items-center">
+        <label className="text-sm text-gray-700">Police</label>
+        <select
+          value={style.fontFamily || 'Inter'}
+          onChange={(e) => handleTextStyleChange(key, 'fontFamily', e.target.value)}
+          className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
+        >
+          {fontOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-2 items-center">
+        <label className="text-sm text-gray-700">Taille</label>
+        <input
+          type="text"
+          value={style.fontSize || ''}
+          onChange={(e) => handleTextStyleChange(key, 'fontSize', e.target.value)}
+          className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
+          placeholder="16px"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2 items-center">
+        <label className="text-sm text-gray-700">Graisse</label>
+        <select
+          value={style.fontWeight || '400'}
+          onChange={(e) => handleTextStyleChange(key, 'fontWeight', e.target.value)}
+          className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
+        >
+          {weightOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+        </select>
+      </div>
+      <div className="grid grid-cols-2 gap-2 items-center">
+        <label className="text-sm text-gray-700">Alignement</label>
+        <select
+          value={style.textAlign || 'left'}
+          onChange={(e) => handleTextStyleChange(key, 'textAlign', e.target.value)}
+          className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
+        >
+          {alignOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+        </select>
+      </div>
+      {renderColorInput(style.color || '#000000', (val) => handleTextStyleChange(key, 'color', val), 'Couleur')}
+      <div className="grid grid-cols-2 gap-2 items-center">
+        <label className="text-sm text-gray-700">Interligne</label>
+        <input
+          type="text"
+          value={style.lineHeight || ''}
+          onChange={(e) => handleTextStyleChange(key, 'lineHeight', e.target.value)}
+          className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
+          placeholder="1.5"
+        />
+      </div>
+    </div>
+  );
   const fontOptions = [{
     value: 'Inter',
     label: 'Inter'
@@ -320,6 +391,14 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
     value: 'large',
     label: 'L'
   }];
+  const weightOptions = [{ value: '300', label: 'Light' }, { value: '400', label: 'Regular' }, { value: '700', label: 'Bold' }];
+  const alignOptions = [{ value: 'left', label: 'Gauche' }, { value: 'center', label: 'Centre' }, { value: 'right', label: 'Droite' }];
+  const textStyles = campaign.design?.textStyles || {
+    title: {},
+    description: {},
+    label: {},
+    button: {}
+  };
   const customText = campaign.design?.customText || {
     enabled: false,
     text: 'Texte personnalisé',
@@ -552,20 +631,10 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
           </h4>
           
           {renderColorInput(campaign.design?.background || '#f8fafc', (val) => handleDesignChange('background', val), 'Fond')}
-          {renderColorInput(campaign.design?.titleColor || '#000000', (val) => handleDesignChange('titleColor', val), 'Texte')}
-
-          <div className="grid grid-cols-2 gap-2 items-center">
-            <label className="text-sm text-gray-700">Police</label>
-            <select
-              value={campaign.design?.fontFamily || 'Inter'}
-              onChange={(e) => handleDesignChange('fontFamily', e.target.value)}
-              className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-[#841b60] focus:border-transparent"
-            >
-              {fontOptions.map(font => <option key={font.value} value={font.value}>
-                  {font.label}
-                </option>)}
-            </select>
-          </div>
+          {renderTextStyleEditor('title', textStyles.title || {}, 'Titres')}
+          {renderTextStyleEditor('description', textStyles.description || {}, 'Descriptions')}
+          {renderTextStyleEditor('label', textStyles.label || {}, 'Libellés')}
+          {renderTextStyleEditor('button', textStyles.button || {}, 'Boutons')}
         </div>
       </AccordionSection>
 

--- a/src/components/Newsletter/PreviewContent.tsx
+++ b/src/components/Newsletter/PreviewContent.tsx
@@ -36,21 +36,20 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ campaign, step = 'game'
     if (isComplete) {
       return (
         <div className="flex flex-col items-center justify-center text-center h-full w-full max-w-2xl mx-auto px-4">
-          <h2 
+          <h2
             className="text-3xl font-bold mb-6"
-            style={{ 
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+            style={{
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[3].title || 'Félicitations !'}
           </h2>
           
-          <p 
+          <p
             className="text-xl"
-            style={{ 
-              color: Color(campaign.design.blockColor || '#FFFFFF').isDark() ? '#FFFFFF' : '#000000',
-              fontFamily: campaign.design.textFont
+            style={{
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || (Color(campaign.design.blockColor || '#FFFFFF').isDark() ? '#FFFFFF' : '#000000')
             }}
           >
             {campaign.screens[3].description || 'Merci pour votre participation !'}

--- a/src/components/campaign/FormEditor.tsx
+++ b/src/components/campaign/FormEditor.tsx
@@ -223,6 +223,10 @@ const FormEditor: React.FC<FormEditorProps> = ({
                 fields={fields}
                 onSubmit={handlePreview}
                 submitLabel="Aperçu - Valider"
+                textStyles={{
+                  label: campaign.design.textStyles?.label,
+                  button: campaign.design.textStyles?.button
+                }}
               />
             </div>
           )}

--- a/src/components/forms/DynamicContactForm.tsx
+++ b/src/components/forms/DynamicContactForm.tsx
@@ -17,6 +17,10 @@ interface DynamicContactFormProps {
   submitLabel?: string;
   defaultValues?: Record<string, string>;
   className?: string;
+  textStyles?: {
+    label?: React.CSSProperties;
+    button?: React.CSSProperties;
+  };
 }
 
 const DynamicContactForm: React.FC<DynamicContactFormProps> = ({
@@ -24,7 +28,8 @@ const DynamicContactForm: React.FC<DynamicContactFormProps> = ({
   onSubmit,
   submitLabel = "Envoyer",
   defaultValues = {},
-  className = ""
+  className = "",
+  textStyles
 }) => {
   const [formData, setFormData] = useState<Record<string, string>>(defaultValues);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -148,7 +153,7 @@ const DynamicContactForm: React.FC<DynamicContactFormProps> = ({
       {fields.map(field => (
         <div key={field.id}>
           {field.type !== 'checkbox' && (
-            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor={field.id}>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor={field.id} style={textStyles?.label}>
               {field.label}
               {field.required && <span className="text-red-500 ml-1">*</span>}
             </label>
@@ -165,6 +170,7 @@ const DynamicContactForm: React.FC<DynamicContactFormProps> = ({
       <button
         type="submit"
         className="w-full px-6 py-3 font-medium transition-colors duration-200 bg-[#841b60] text-white rounded-lg hover:bg-[#6d1550]"
+        style={textStyles?.button}
       >
         {submitLabel}
       </button>

--- a/src/components/funnels/FunnelStandard.tsx
+++ b/src/components/funnels/FunnelStandard.tsx
@@ -79,8 +79,7 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <h2
             className="text-2xl font-bold mb-4"
             style={{
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[0]?.title || 'Ready to Play?'}
@@ -88,8 +87,8 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <p
             className="mb-6"
             style={{
-              color: getContrastColor(campaign.design.blockColor),
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || getContrastColor(campaign.design.blockColor)
             }}
           >
             {campaign.screens[0]?.description || 'Click below to participate'}
@@ -99,9 +98,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             className="px-8 py-3 font-medium transition-colors duration-200 hover:opacity-90"
             style={{
               backgroundColor: campaign.design.buttonColor,
-              color: getContrastColor(campaign.design.buttonColor),
               borderRadius: campaign.design.borderRadius,
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.button,
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor)
             }}
           >
             {campaign.screens[0]?.buttonText || 'Participate'}
@@ -114,8 +113,7 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <h2
             className="text-2xl font-bold mb-4"
             style={{
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[1]?.title || 'Your Information'}
@@ -124,6 +122,10 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             fields={fields}
             submitLabel={participationLoading ? "Chargement..." : (campaign.screens[1]?.buttonText || "Continuer")}
             onSubmit={handleFormSubmit}
+            textStyles={{
+              label: campaign.design.textStyles?.label,
+              button: campaign.design.textStyles?.button
+            }}
           />
         </div>
       )}
@@ -132,17 +134,18 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
         <div className="w-full p-6">
           {getGameComponent()}
           <div className="mt-6 text-center">
-            <button
-              onClick={handleEnd}
-              className="px-6 py-3 transition-colors duration-200 hover:opacity-90"
-              style={{
-                backgroundColor: campaign.design.buttonColor,
-                color: getContrastColor(campaign.design.buttonColor),
-                borderRadius: campaign.design.borderRadius
-              }}
-            >
-              {campaign.screens[2]?.buttonText || 'Submit'}
-            </button>
+          <button
+            onClick={handleEnd}
+            className="px-6 py-3 transition-colors duration-200 hover:opacity-90"
+            style={{
+              backgroundColor: campaign.design.buttonColor,
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
+              borderRadius: campaign.design.borderRadius,
+              ...campaign.design.textStyles?.button
+            }}
+          >
+            {campaign.screens[2]?.buttonText || 'Submit'}
+          </button>
           </div>
         </div>
       )}
@@ -152,8 +155,7 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <h2
             className="text-3xl font-bold mb-4"
             style={{
-              color: campaign.design.titleColor,
-              fontFamily: campaign.design.titleFont
+              ...campaign.design.textStyles?.title
             }}
           >
             {campaign.screens[3]?.confirmationTitle || 'Thank you!'}
@@ -161,8 +163,8 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
           <p
             className="mb-6"
             style={{
-              color: getContrastColor(campaign.design.blockColor),
-              fontFamily: campaign.design.textFont
+              ...campaign.design.textStyles?.description,
+              color: campaign.design.textStyles?.description?.color || getContrastColor(campaign.design.blockColor)
             }}
           >
             {campaign.screens[3]?.confirmationMessage || 'Your participation has been recorded.'}
@@ -172,8 +174,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
             className="px-6 py-3 font-medium transition-colors duration-200 hover:opacity-90"
             style={{
               backgroundColor: campaign.design.buttonColor,
-              color: getContrastColor(campaign.design.buttonColor),
-              borderRadius: campaign.design.borderRadius
+              color: campaign.design.textStyles?.button?.color || getContrastColor(campaign.design.buttonColor),
+              borderRadius: campaign.design.borderRadius,
+              ...campaign.design.textStyles?.button
             }}
           >
             {campaign.screens[3]?.replayButtonText || 'Play Again'}

--- a/src/components/funnels/components/FormHandler.tsx
+++ b/src/components/funnels/components/FormHandler.tsx
@@ -55,6 +55,10 @@ const FormHandler: React.FC<FormHandlerProps> = ({
         fields={convertedFields}
         submitLabel={participationLoading ? 'Chargement...' : campaign.screens?.[1]?.buttonText || "C'est parti !"}
         onSubmit={onSubmit}
+        textStyles={{
+          label: campaign.design.textStyles?.label,
+          button: campaign.design.textStyles?.button
+        }}
       />
     </Modal>
   );

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -68,6 +68,40 @@ const ModernCampaignEditor: React.FC = () => {
       buttonColor: '#841b60',
       fontFamily: 'Inter',
       borderRadius: '0.5rem',
+      textStyles: {
+        title: {
+          fontFamily: 'Inter',
+          fontSize: '24px',
+          fontWeight: 'bold',
+          textAlign: 'center' as const,
+          color: '#000000',
+          lineHeight: '1.2'
+        },
+        description: {
+          fontFamily: 'Inter',
+          fontSize: '16px',
+          fontWeight: 'normal',
+          textAlign: 'left' as const,
+          color: '#000000',
+          lineHeight: '1.5'
+        },
+        label: {
+          fontFamily: 'Inter',
+          fontSize: '14px',
+          fontWeight: 'normal',
+          textAlign: 'left' as const,
+          color: '#000000',
+          lineHeight: '1.4'
+        },
+        button: {
+          fontFamily: 'Inter',
+          fontSize: '16px',
+          fontWeight: 'bold',
+          textAlign: 'center' as const,
+          color: '#ffffff',
+          lineHeight: '1.2'
+        }
+      },
       // Custom text configuration
       customText: {
         enabled: false,


### PR DESCRIPTION
## Summary
- expand campaign design defaults with `textStyles`
- allow editing per-element typography in design tab
- apply text styles in funnels and preview components
- pass style options to dynamic form

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684457da5f64832a8e7b46bf06afb85f