### PR TITLE
Add Mobile tab in modern editor

### DIFF
--- a/src/components/CampaignEditor/CampaignDesign.tsx
+++ b/src/components/CampaignEditor/CampaignDesign.tsx
@@ -152,11 +152,17 @@ const CampaignDesign: React.FC<CampaignDesignProps> = ({ campaign, setCampaign }
             value={campaign.design.logoUrl}
             onChange={(value) => updateDesign('logoUrl', value)}
           />
-          
+
           <ImageUpload
             label="Image d'arrière-plan générale"
             value={campaign.design.backgroundImage}
             onChange={(value) => updateDesign('backgroundImage', value)}
+          />
+
+          <ImageUpload
+            label="Image d'arrière-plan mobile"
+            value={campaign.design.mobileBackgroundImage}
+            onChange={(value) => updateDesign('mobileBackgroundImage', value)}
           />
         </div>
       </div>

--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -5,13 +5,16 @@ import FunnelStandard from '../funnels/FunnelStandard';
 
 interface CampaignPreviewProps {
   campaign: any;
+  previewDevice?: 'desktop' | 'tablet' | 'mobile';
 }
 
-const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign }) => {
+const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevice = 'desktop' }) => {
   const { design } = campaign;
 
-  // Get background image from design or game config
-  const backgroundImage = design?.backgroundImage || campaign.gameConfig?.[campaign.type]?.backgroundImage;
+  // Get background image depending on device
+  const baseBackground = design?.backgroundImage || campaign.gameConfig?.[campaign.type]?.backgroundImage;
+  const mobileBackground = design?.mobileBackgroundImage;
+  const backgroundImage = previewDevice === 'mobile' && mobileBackground ? mobileBackground : baseBackground;
 
   const containerStyle = {
     width: '100%',
@@ -79,7 +82,7 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign }) => {
       return (
         <FunnelUnlockedGame
           campaign={enhancedCampaign}
-          previewMode="desktop"
+          previewMode={previewDevice}
           modalContained={false}
         />
       );

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -95,6 +95,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
         >
           <CampaignPreview
             campaign={campaign}
+            previewDevice={selectedDevice}
             key={`mobile-${campaign.id}-${JSON.stringify({
               gameConfig: campaign.gameConfig,
               design: campaign.design,

--- a/src/components/ModernEditor/ModernEditorSidebar.tsx
+++ b/src/components/ModernEditor/ModernEditorSidebar.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Settings, Gamepad2, Palette, FormInput, Sliders } from 'lucide-react';
+import { Settings, Gamepad2, Palette, FormInput, Sliders, Smartphone } from 'lucide-react';
 import { CampaignType } from '../../utils/campaignTypes';
 
 interface ModernEditorSidebarProps {
@@ -26,7 +26,8 @@ const ModernEditorSidebar: React.FC<ModernEditorSidebarProps> = ({
     { id: 'game', label: 'Jeu', icon: Gamepad2 },
     { id: 'gameconfig', label: 'Configuration', icon: Sliders, description: 'Taille et position' },
     { id: 'design', label: 'Design', icon: Palette },
-    { id: 'form', label: 'Formulaire', icon: FormInput }
+    { id: 'form', label: 'Formulaire', icon: FormInput },
+    { id: 'mobile', label: 'Mobile', icon: Smartphone }
   ];
 
   return (

--- a/src/components/ModernEditor/ModernMobileTab.tsx
+++ b/src/components/ModernEditor/ModernMobileTab.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CampaignMobile from '../CampaignEditor/CampaignMobile';
+
+interface ModernMobileTabProps {
+  campaign: any;
+  setCampaign: React.Dispatch<React.SetStateAction<any>>;
+}
+
+const ModernMobileTab: React.FC<ModernMobileTabProps> = ({ campaign, setCampaign }) => {
+  return <CampaignMobile campaign={campaign} setCampaign={setCampaign} />;
+};
+
+export default ModernMobileTab;

--- a/src/components/QuickCampaign/Preview/PreviewContent.tsx
+++ b/src/components/QuickCampaign/Preview/PreviewContent.tsx
@@ -98,11 +98,15 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
       overflow: 'hidden' as const
     };
 
-    // Background image if available
-    if (enhancedCampaign.design?.backgroundImage) {
+    const mobileBg = enhancedCampaign.design?.mobileBackgroundImage;
+    const bgImage = selectedDevice === 'mobile' && mobileBg
+      ? mobileBg
+      : enhancedCampaign.design?.backgroundImage;
+
+    if (bgImage) {
       return {
         ...baseStyle,
-        backgroundImage: `url(${enhancedCampaign.design.backgroundImage})`,
+        backgroundImage: `url(${bgImage})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat'
@@ -148,8 +152,10 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
         <div style={getDeviceContainerStyle()}>
           <div style={getContainerStyle()}>
             {/* Background overlay for better contrast if background image exists */}
-            {enhancedCampaign.design?.backgroundImage && (
-              <div 
+            {(selectedDevice === 'mobile'
+              ? enhancedCampaign.design?.mobileBackgroundImage
+              : enhancedCampaign.design?.backgroundImage) && (
+              <div
                 className="absolute inset-0 bg-black opacity-20"
                 style={{ zIndex: 1 }}
               />

--- a/src/pages/CampaignEditor.tsx
+++ b/src/pages/CampaignEditor.tsx
@@ -102,7 +102,8 @@ const CampaignEditor: React.FC = () => {
       fontSize: 'normal',
       fontWeight: 'normal',
       logoUrl: '',
-      backgroundImage: ''
+      backgroundImage: '',
+      mobileBackgroundImage: ''
     },
     rewards: {
       mode: 'probability',

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -12,6 +12,7 @@ import ModernGameTab from '../components/ModernEditor/ModernGameTab';
 import ModernDesignTab from '../components/ModernEditor/ModernDesignTab';
 import ModernFormTab from '../components/ModernEditor/ModernFormTab';
 import ModernGameConfigTab from '../components/ModernEditor/ModernGameConfigTab';
+import ModernMobileTab from '../components/ModernEditor/ModernMobileTab';
 
 const defaultFormFields = [
   { id: 'prenom', label: 'Prénom', type: 'text', required: true },
@@ -284,6 +285,12 @@ const ModernCampaignEditor: React.FC = () => {
                 )}
                 {activeTab === 'form' && (
                   <ModernFormTab
+                    campaign={campaign}
+                    setCampaign={setCampaign}
+                  />
+                )}
+                {activeTab === 'mobile' && (
+                  <ModernMobileTab
                     campaign={campaign}
                     setCampaign={setCampaign}
                   />

--- a/src/stores/quickCampaignStore.ts
+++ b/src/stores/quickCampaignStore.ts
@@ -86,7 +86,8 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
       type: state.selectedGameType || 'wheel',
       design: {
         customColors: state.customColors,
-        centerLogo: null
+        centerLogo: null,
+        mobileBackgroundImage: null
       },
       buttonConfig: {
         color: state.customColors.primary,


### PR DESCRIPTION
## Summary
- include a new `ModernMobileTab` that reuses the existing mobile configuration UI
- update the sidebar to show a Mobile tab
- render the new tab in the modern campaign editor

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844585d2820832abb712f684a0215db