### PR TITLE
Fix mobile tab preview

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import GameRenderer from './GameRenderer';
 import { useGamePositionCalculator } from './GamePositionCalculator';
 import { GAME_SIZES, GameSize } from '../configurators/GameSizeSelector';
+import MobilePreview from './Mobile/MobilePreview';
 interface GameCanvasPreviewProps {
   campaign: any;
   className?: string;
@@ -12,6 +13,13 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   className = "",
   previewDevice = 'desktop'
 }) => {
+  if (previewDevice === 'mobile' || previewDevice === 'tablet') {
+    return (
+      <div className={`w-full h-full ${className}`}>
+        <MobilePreview campaign={campaign} previewMode={previewDevice} />
+      </div>
+    );
+  }
   const baseBackgroundImage = campaign.gameConfig?.[campaign.type]?.backgroundImage || campaign.design?.backgroundImage;
   const mobileBackgroundImage = campaign.design?.mobileBackgroundImage;
   const gameBackgroundImage = previewDevice === 'mobile' && mobileBackgroundImage


### PR DESCRIPTION
## Summary
- ensure GameCanvasPreview renders full MobilePreview when previewing on mobile or tablet

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684470cc7cd8832aa2b6b91700d9bbd8