### PR TITLE
Add editable text zones in preview editor

### DIFF
--- a/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
+++ b/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
@@ -12,6 +12,8 @@ interface FreeTextZone {
     color: string;
     textAlign: 'left' | 'center' | 'right';
     fontFamily: string;
+    lineHeight: number;
+    letterSpacing: number;
   };
   // Device-specific positioning and sizing
   mobile: {
@@ -30,7 +32,7 @@ interface FreeTextZone {
 
 interface FreeTextManagerProps {
   containerBounds: { width: number; height: number };
-  previewMode: 'mobile' | 'tablet';
+  previewMode: 'mobile' | 'tablet' | 'desktop';
 }
 
 const FreeTextManager: React.FC<FreeTextManagerProps> = ({ 
@@ -64,7 +66,9 @@ const FreeTextManager: React.FC<FreeTextManagerProps> = ({
         fontWeight: 'normal',
         color: '#000000',
         textAlign: 'left',
-        fontFamily: 'Inter, sans-serif'
+        fontFamily: 'Inter, sans-serif',
+        lineHeight: 1.2,
+        letterSpacing: 0
       },
       mobile: {
         position: { ...defaultPosition },

--- a/src/components/CampaignEditor/Mobile/FreeTextZone.tsx
+++ b/src/components/CampaignEditor/Mobile/FreeTextZone.tsx
@@ -13,6 +13,8 @@ interface FreeTextZoneProps {
     color: string;
     textAlign: 'left' | 'center' | 'right';
     fontFamily: string;
+    lineHeight: number;
+    letterSpacing: number;
   };
   isEditing: boolean;
   onEdit: (id: string) => void;
@@ -101,7 +103,7 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
         top: `${position.y}px`,
         width: `${size.width}px`,
         height: `${size.height}px`,
-        zIndex: 150,
+        zIndex: 200,
         border: isEditing ? '2px dashed #841b60' : '1px solid transparent',
         backgroundColor: 'transparent',
         cursor: isDragging ? 'grabbing' : 'grab',
@@ -130,6 +132,8 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
             color: style.color,
             textAlign: style.textAlign,
             fontFamily: style.fontFamily,
+            lineHeight: style.lineHeight,
+            letterSpacing: `${style.letterSpacing}px`,
             padding: '2px'
           }}
           onClick={(e) => e.stopPropagation()}
@@ -144,6 +148,8 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
             color: style.color,
             textAlign: style.textAlign,
             fontFamily: style.fontFamily,
+            lineHeight: style.lineHeight,
+            letterSpacing: `${style.letterSpacing}px`,
             padding: '2px',
             overflow: 'hidden',
             wordWrap: 'break-word'
@@ -222,6 +228,43 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
               style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
               min="8"
               max="72"
+            />
+            <select
+              value={style.fontWeight}
+              onChange={(e) => onStyleChange(id, { fontWeight: e.target.value })}
+              style={{ padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+            >
+              <option value="normal">Normal</option>
+              <option value="bold">Bold</option>
+              <option value="lighter">Light</option>
+            </select>
+            <select
+              value={style.fontFamily}
+              onChange={(e) => onStyleChange(id, { fontFamily: e.target.value })}
+              style={{ padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+            >
+              <option value="Inter, sans-serif">Inter</option>
+              <option value="Arial, sans-serif">Arial</option>
+              <option value="Helvetica, sans-serif">Helvetica</option>
+              <option value="Georgia, serif">Georgia</option>
+              <option value="Times New Roman, serif">Times</option>
+            </select>
+            <input
+              type="number"
+              value={style.lineHeight}
+              step="0.1"
+              onChange={(e) => onStyleChange(id, { lineHeight: parseFloat(e.target.value) || 1 })}
+              style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+              min="0.5"
+              max="3"
+            />
+            <input
+              type="number"
+              value={style.letterSpacing}
+              onChange={(e) => onStyleChange(id, { letterSpacing: parseFloat(e.target.value) || 0 })}
+              style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+              min="-5"
+              max="20"
             />
             <select
               value={style.textAlign}

--- a/src/components/ModernEditor/ModernEditorCanvas.tsx
+++ b/src/components/ModernEditor/ModernEditorCanvas.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import GameCanvasPreview from '../CampaignEditor/GameCanvasPreview';
+import FreeTextManager from '../CampaignEditor/Mobile/FreeTextManager';
 
 interface ModernEditorCanvasProps {
   campaign: any;
@@ -61,7 +62,14 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
           overflow: 'hidden'
         };
       default:
-        return styleWithBackground;
+        return {
+          ...styleWithBackground,
+          maxWidth: '1080px',
+          maxHeight: '1920px',
+          margin: '0 auto',
+          overflow: 'hidden',
+          position: 'relative'
+        };
     }
   };
 
@@ -122,6 +130,14 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
     center: { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
   };
 
+  const boundsMap: Record<string, { width: number; height: number }> = {
+    desktop: { width: 1080, height: 1920 },
+    tablet: { width: 768, height: 1024 },
+    mobile: { width: 375, height: 812 }
+  };
+
+  const containerBounds = boundsMap[previewDevice];
+
 
   return (
     <div className="w-full h-full flex items-center justify-center bg-gray-100 p-4">
@@ -168,6 +184,7 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
             key={`preview-${gameSize}-${gamePosition}-${campaign.buttonConfig?.color}-${JSON.stringify(campaign.gameConfig?.[campaign.type])}`}
             previewDevice={previewDevice}
           />
+          <FreeTextManager containerBounds={containerBounds} previewMode={previewDevice} />
           {customText?.enabled && (
             <div
               style={{


### PR DESCRIPTION
## Summary
- enhance editable free text zones with new style options and higher z-index
- support desktop mode in free text manager
- enforce 1080x1920 preview bounds and overlay free text manager in editor canvas

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a4f90078832aad2486775653b358