### PR TITLE
Improve free text zone editing

### DIFF
--- a/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
+++ b/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
@@ -12,6 +12,8 @@ interface FreeTextZone {
     color: string;
     textAlign: 'left' | 'center' | 'right';
     fontFamily: string;
+    lineHeight: number;
+    letterSpacing: number;
   };
   // Device-specific positioning and sizing
   mobile: {
@@ -30,7 +32,7 @@ interface FreeTextZone {
 
 interface FreeTextManagerProps {
   containerBounds: { width: number; height: number };
-  previewMode: 'mobile' | 'tablet';
+  previewMode: 'mobile' | 'tablet' | 'desktop';
 }
 
 const FreeTextManager: React.FC<FreeTextManagerProps> = ({ 
@@ -58,13 +60,15 @@ const FreeTextManager: React.FC<FreeTextManagerProps> = ({
 
     const newZone: FreeTextZone = {
       id: `free-text-${Date.now()}`,
-      content: 'Nouveau texte',
+      content: '',
       style: {
         fontSize: 16,
         fontWeight: 'normal',
         color: '#000000',
         textAlign: 'left',
-        fontFamily: 'Inter, sans-serif'
+        fontFamily: 'Inter, sans-serif',
+        lineHeight: 1.2,
+        letterSpacing: 0
       },
       mobile: {
         position: { ...defaultPosition },

--- a/src/components/CampaignEditor/Mobile/FreeTextZone.tsx
+++ b/src/components/CampaignEditor/Mobile/FreeTextZone.tsx
@@ -13,6 +13,8 @@ interface FreeTextZoneProps {
     color: string;
     textAlign: 'left' | 'center' | 'right';
     fontFamily: string;
+    lineHeight: number;
+    letterSpacing: number;
   };
   isEditing: boolean;
   onEdit: (id: string) => void;
@@ -101,12 +103,15 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
         top: `${position.y}px`,
         width: `${size.width}px`,
         height: `${size.height}px`,
-        zIndex: 150,
+        zIndex: 200,
         border: isEditing ? '2px dashed #841b60' : '1px solid transparent',
         backgroundColor: 'transparent',
         cursor: isDragging ? 'grabbing' : 'grab',
         userSelect: 'none',
         overflow: 'hidden'
+      }}
+      onMouseDown={(e) => {
+        if (isEditing) handleMouseDown(e, 'drag');
       }}
       onClick={(e) => {
         e.stopPropagation();
@@ -130,6 +135,8 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
             color: style.color,
             textAlign: style.textAlign,
             fontFamily: style.fontFamily,
+            lineHeight: style.lineHeight,
+            letterSpacing: `${style.letterSpacing}px`,
             padding: '2px'
           }}
           onClick={(e) => e.stopPropagation()}
@@ -144,6 +151,8 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
             color: style.color,
             textAlign: style.textAlign,
             fontFamily: style.fontFamily,
+            lineHeight: style.lineHeight,
+            letterSpacing: `${style.letterSpacing}px`,
             padding: '2px',
             overflow: 'hidden',
             wordWrap: 'break-word'
@@ -199,14 +208,18 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
           <div
             style={{
               position: 'absolute',
-              top: '-20px',
-              right: '0px',
+              bottom: '100%',
+              left: '0px',
+              transform: 'translateY(-4px)',
               background: 'rgba(255, 255, 255, 0.9)',
               padding: '4px',
               borderRadius: '4px',
               display: 'flex',
+              flexWrap: 'wrap',
               gap: '4px',
-              fontSize: '10px'
+              fontSize: '10px',
+              maxHeight: '140px',
+              overflowY: 'auto'
             }}
           >
             <input
@@ -222,6 +235,43 @@ const FreeTextZone: React.FC<FreeTextZoneProps> = ({
               style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
               min="8"
               max="72"
+            />
+            <select
+              value={style.fontWeight}
+              onChange={(e) => onStyleChange(id, { fontWeight: e.target.value })}
+              style={{ padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+            >
+              <option value="normal">Normal</option>
+              <option value="bold">Bold</option>
+              <option value="lighter">Light</option>
+            </select>
+            <select
+              value={style.fontFamily}
+              onChange={(e) => onStyleChange(id, { fontFamily: e.target.value })}
+              style={{ padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+            >
+              <option value="Inter, sans-serif">Inter</option>
+              <option value="Arial, sans-serif">Arial</option>
+              <option value="Helvetica, sans-serif">Helvetica</option>
+              <option value="Georgia, serif">Georgia</option>
+              <option value="Times New Roman, serif">Times</option>
+            </select>
+            <input
+              type="number"
+              value={style.lineHeight}
+              step="0.1"
+              onChange={(e) => onStyleChange(id, { lineHeight: parseFloat(e.target.value) || 1 })}
+              style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+              min="0.5"
+              max="3"
+            />
+            <input
+              type="number"
+              value={style.letterSpacing}
+              onChange={(e) => onStyleChange(id, { letterSpacing: parseFloat(e.target.value) || 0 })}
+              style={{ width: '40px', padding: '2px', border: '1px solid #ccc', borderRadius: '2px' }}
+              min="-5"
+              max="20"
             />
             <select
               value={style.textAlign}

--- a/src/components/CampaignEditor/Mobile/TextZoneManager.tsx
+++ b/src/components/CampaignEditor/Mobile/TextZoneManager.tsx
@@ -29,20 +29,27 @@ const TextZoneManager: React.FC<TextZoneManagerProps> = ({
   gameArea,
   containerBounds
 }) => {
-  const [textZones, setTextZones] = useState<TextZone[]>([
-    {
-      id: 'main-text',
-      position: { x: 20, y: 20 },
-      size: { width: 200, height: 80 },
-      content: {
-        title: campaign?.screens?.[1]?.title || 'Bienvenue !',
-        description: campaign?.screens?.[1]?.description || 'Participez à notre jeu et tentez de gagner !',
-        showTitle: mobileConfig.showTitle !== false,
-        showDescription: mobileConfig.showDescription !== false
-      }
+  const [textZones, setTextZones] = useState<TextZone[]>(() => {
+    const initialTitle = campaign?.screens?.[1]?.title || '';
+    const initialDescription = campaign?.screens?.[1]?.description || '';
+    if (initialTitle || initialDescription) {
+      return [
+        {
+          id: 'main-text',
+          position: { x: 20, y: 20 },
+          size: { width: 200, height: 80 },
+          content: {
+            title: initialTitle,
+            description: initialDescription,
+            showTitle: mobileConfig.showTitle !== false,
+            showDescription: mobileConfig.showDescription !== false,
+          },
+        },
+      ];
     }
-  ]);
-  const [selectedZone, setSelectedZone] = useState<string | null>('main-text');
+    return [];
+  });
+  const [selectedZone, setSelectedZone] = useState<string | null>(null);
 
   const handlePositionChange = (id: string, position: { x: number; y: number }) => {
     setTextZones(zones => 
@@ -66,8 +73,8 @@ const TextZoneManager: React.FC<TextZoneManagerProps> = ({
       position: { x: 50, y: 120 },
       size: { width: 180, height: 60 },
       content: {
-        title: 'Nouveau titre',
-        description: 'Nouvelle description',
+        title: '',
+        description: '',
         showTitle: true,
         showDescription: true
       }
@@ -77,9 +84,8 @@ const TextZoneManager: React.FC<TextZoneManagerProps> = ({
   };
 
   const removeTextZone = (id: string) => {
-    if (id === 'main-text') return; // Don't allow removing main text zone
     setTextZones(zones => zones.filter(zone => zone.id !== id));
-    setSelectedZone('main-text');
+    setSelectedZone(null);
   };
 
   const renderTextContent = (zone: TextZone) => {

--- a/src/components/ModernEditor/ModernEditorCanvas.tsx
+++ b/src/components/ModernEditor/ModernEditorCanvas.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import GameCanvasPreview from '../CampaignEditor/GameCanvasPreview';
+import FreeTextManager from '../CampaignEditor/Mobile/FreeTextManager';
 
 interface ModernEditorCanvasProps {
   campaign: any;
@@ -61,7 +62,14 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
           overflow: 'hidden'
         };
       default:
-        return styleWithBackground;
+        return {
+          ...styleWithBackground,
+          maxWidth: '1080px',
+          maxHeight: '1920px',
+          margin: '0 auto',
+          overflow: 'hidden',
+          position: 'relative'
+        };
     }
   };
 
@@ -122,6 +130,14 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
     center: { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
   };
 
+  const boundsMap: Record<string, { width: number; height: number }> = {
+    desktop: { width: 1080, height: 1920 },
+    tablet: { width: 768, height: 1024 },
+    mobile: { width: 375, height: 812 }
+  };
+
+  const containerBounds = boundsMap[previewDevice];
+
 
   return (
     <div className="w-full h-full flex items-center justify-center bg-gray-100 p-4">
@@ -168,6 +184,7 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
             key={`preview-${gameSize}-${gamePosition}-${campaign.buttonConfig?.color}-${JSON.stringify(campaign.gameConfig?.[campaign.type])}`}
             previewDevice={previewDevice}
           />
+          <FreeTextManager containerBounds={containerBounds} previewMode={previewDevice} />
           {customText?.enabled && (
             <div
               style={{

--- a/src/pages/CampaignEditor.tsx
+++ b/src/pages/CampaignEditor.tsx
@@ -64,18 +64,18 @@ const CampaignEditor: React.FC = () => {
     type: campaignType,
     screens: {
       1: {
-        title: 'Bienvenue !',
-        description: 'Participez à notre jeu et tentez de gagner !',
-        buttonText: 'Participer',
+        title: '',
+        description: '',
+        buttonText: '',
         buttonLink: '',
         showTitle: true,
         showDescription: true
       },
       2: {},
       3: {
-        title: 'Félicitations !',
-        description: 'Merci pour votre participation !',
-        buttonText: 'Rejouer',
+        title: '',
+        description: '',
+        buttonText: '',
         buttonLink: '',
         showTitle: true,
         showDescription: true,

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -126,15 +126,15 @@ const ModernCampaignEditor: React.FC = () => {
     },
     screens: {
       1: {
-        title: 'Bienvenue !',
-        description: 'Participez à notre jeu et tentez de gagner !',
-        buttonText: 'Participer',
+        title: '',
+        description: '',
+        buttonText: '',
         showTitle: true,
         showDescription: true
       },
       3: {
-        title: 'Félicitations !',
-        description: 'Merci pour votre participation !',
+        title: '',
+        description: '',
         showTitle: true,
         showDescription: true
       }


### PR DESCRIPTION
## Summary
- remove default text in screen templates
- avoid auto-creating main text zone
- create blank free text zones and allow drag from anywhere
- reposition style controls with scrolling

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a4f90078832aad2486775653b358