### PR TITLE
Add Free Text Zone support

### DIFF
--- a/src/components/CampaignEditor/CampaignMobile.tsx
+++ b/src/components/CampaignEditor/CampaignMobile.tsx
@@ -117,7 +117,11 @@ const CampaignMobile: React.FC<CampaignMobileProps> = ({
           {/* Preview - Better centered and sized */}
           <div className="flex-1 p-6 flex items-center justify-center overflow-y-auto bg-gradient-to-br from-gray-100 to-gray-200">
             <div className="flex justify-center items-center w-full h-full">
-              <MobilePreview campaign={campaign} previewMode={previewMode} />
+              <MobilePreview
+                campaign={campaign}
+                setCampaign={setCampaign}
+                previewMode={previewMode}
+              />
             </div>
           </div>
         </div>

--- a/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
+++ b/src/components/CampaignEditor/Mobile/FreeTextManager.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import FreeTextZone from './FreeTextZone';
 import { Plus, Type } from 'lucide-react';
 
@@ -33,13 +33,27 @@ interface FreeTextZone {
 interface FreeTextManagerProps {
   containerBounds: { width: number; height: number };
   previewMode: 'mobile' | 'tablet' | 'desktop';
+  zones?: FreeTextZone[];
+  onChange?: (zones: FreeTextZone[]) => void;
 }
 
-const FreeTextManager: React.FC<FreeTextManagerProps> = ({ 
-  containerBounds, 
-  previewMode
+const FreeTextManager: React.FC<FreeTextManagerProps> = ({
+  containerBounds,
+  previewMode,
+  zones,
+  onChange
 }) => {
   const [freeTextZones, setFreeTextZones] = useState<FreeTextZone[]>([]);
+
+  useEffect(() => {
+    if (zones) {
+      setFreeTextZones(zones);
+    }
+  }, [zones]);
+
+  useEffect(() => {
+    onChange?.(freeTextZones);
+  }, [freeTextZones, onChange]);
   const [editingZone, setEditingZone] = useState<string>('');
   const [isPlacementMode, setIsPlacementMode] = useState(false);
 

--- a/src/components/CampaignEditor/Mobile/MobilePreview.tsx
+++ b/src/components/CampaignEditor/Mobile/MobilePreview.tsx
@@ -10,11 +10,13 @@ import { getDeviceStyle, getScreenStyle } from './styles';
 interface MobilePreviewProps {
   campaign: any;
   previewMode: 'mobile' | 'tablet';
+  setCampaign?: React.Dispatch<React.SetStateAction<any>>;
 }
 
 const MobilePreview: React.FC<MobilePreviewProps> = ({
   campaign,
-  previewMode
+  previewMode,
+  setCampaign
 }) => {
   const fallbackMobile = campaign.config?.mobileConfig || {};
   const mobileConfig = { ...fallbackMobile, ...(campaign.mobileConfig || {}) };
@@ -127,9 +129,13 @@ const MobilePreview: React.FC<MobilePreviewProps> = ({
         />
 
         {/* Free Text Manager - Enhanced with device-specific positioning */}
-        <FreeTextManager 
-          containerBounds={containerBounds} 
+        <FreeTextManager
+          containerBounds={containerBounds}
           previewMode={previewMode}
+          zones={campaign.freeTextZones}
+          onChange={(zones) =>
+            setCampaign?.((prev: any) => ({ ...prev, freeTextZones: zones }))
+          }
         />
 
         {/* Button Layer - only show if not hidden */}

--- a/src/components/ModernEditor/ModernEditorCanvas.tsx
+++ b/src/components/ModernEditor/ModernEditorCanvas.tsx
@@ -7,13 +7,15 @@ interface ModernEditorCanvasProps {
   previewDevice: 'desktop' | 'tablet' | 'mobile';
   gameSize: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition: 'top' | 'center' | 'bottom' | 'left' | 'right';
+  onFreeTextZonesChange?: (zones: any[]) => void;
 }
 
 const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
   campaign,
   previewDevice,
   gameSize,
-  gamePosition
+  gamePosition,
+  onFreeTextZonesChange
 }) => {
 
   const getCanvasStyle = () => {
@@ -184,7 +186,12 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
             key={`preview-${gameSize}-${gamePosition}-${campaign.buttonConfig?.color}-${JSON.stringify(campaign.gameConfig?.[campaign.type])}`}
             previewDevice={previewDevice}
           />
-          <FreeTextManager containerBounds={containerBounds} previewMode={previewDevice} />
+          <FreeTextManager
+            containerBounds={containerBounds}
+            previewMode={previewDevice}
+            zones={campaign.freeTextZones}
+            onChange={onFreeTextZonesChange}
+          />
           {customText?.enabled && (
             <div
               style={{

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -8,6 +8,7 @@ export interface Campaign {
   name: string;
   description?: string;
   type: string;
+  free_text_zones?: any[];
   form_fields?: FormField[];
   game_config?: any;
   design?: any;
@@ -36,6 +37,7 @@ export const useCampaigns = () => {
             description: campaignData.description,
             type: campaignData.type,
             form_fields: campaignData.form_fields || [],
+            free_text_zones: campaignData.free_text_zones || [],
             game_config: campaignData.game_config,
             design: campaignData.design,
             screens: campaignData.screens,
@@ -61,6 +63,7 @@ export const useCampaigns = () => {
             description: campaignData.description,
             type: campaignData.type,
             form_fields: campaignData.form_fields || [],
+            free_text_zones: campaignData.free_text_zones || [],
             game_config: campaignData.game_config,
             design: campaignData.design,
             screens: campaignData.screens,
@@ -103,7 +106,10 @@ export const useCampaigns = () => {
         return null;
       }
 
-      return data;
+      return {
+        ...data,
+        free_text_zones: data?.free_text_zones || []
+      } as Campaign;
     } catch (err) {
       console.error('Erreur inattendue:', err);
       setError('Une erreur inattendue s\'est produite');
@@ -129,7 +135,12 @@ export const useCampaigns = () => {
         return [];
       }
 
-      return data || [];
+      return (
+        data?.map((c: any) => ({
+          ...c,
+          free_text_zones: c.free_text_zones || []
+        })) || []
+      );
     } catch (err) {
       console.error('Erreur inattendue:', err);
       setError('Une erreur inattendue s\'est produite');

--- a/src/pages/CampaignEditor.tsx
+++ b/src/pages/CampaignEditor.tsx
@@ -119,6 +119,7 @@ const CampaignEditor: React.FC = () => {
         pointerColor: '#841b60'
       }
     },
+    freeTextZones: [],
     mobileConfig: {
       roulette: {
         segments: [],
@@ -187,14 +188,16 @@ const CampaignEditor: React.FC = () => {
     if (existingCampaign) {
       setCampaign({
         ...existingCampaign,
-        formFields: existingCampaign.form_fields || defaultFormFields
+        formFields: existingCampaign.form_fields || defaultFormFields,
+        freeTextZones: existingCampaign.free_text_zones || []
       });
     }
   };
   const handleSave = async (continueEditing = false) => {
     const campaignData = {
       ...campaign,
-      form_fields: campaign.formFields
+      form_fields: campaign.formFields,
+      free_text_zones: campaign.freeTextZones
     };
     const savedCampaign = await saveCampaign(campaignData);
     if (savedCampaign && !continueEditing) {

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -138,7 +138,8 @@ const ModernCampaignEditor: React.FC = () => {
         showTitle: true,
         showDescription: true
       }
-    }
+    },
+    freeTextZones: []
   });
 
   useEffect(() => {
@@ -154,7 +155,8 @@ const ModernCampaignEditor: React.FC = () => {
       if (existingCampaign) {
         setCampaign({
           ...existingCampaign,
-          formFields: existingCampaign.form_fields || defaultFormFields
+          formFields: existingCampaign.form_fields || defaultFormFields,
+          freeTextZones: existingCampaign.free_text_zones || []
         });
       }
     } finally {
@@ -167,7 +169,8 @@ const ModernCampaignEditor: React.FC = () => {
     try {
       const campaignData = {
         ...campaign,
-        form_fields: campaign.formFields
+        form_fields: campaign.formFields,
+        free_text_zones: campaign.freeTextZones
       };
       const savedCampaign = await saveCampaign(campaignData);
       if (savedCampaign && !continueEditing) {
@@ -291,7 +294,15 @@ const ModernCampaignEditor: React.FC = () => {
 
           {/* Canvas Preview */}
           <div className="flex-1 bg-gray-100">
-            <ModernEditorCanvas campaign={campaign} previewDevice={previewDevice} gameSize={campaign.gameSize} gamePosition={campaign.gamePosition} />
+            <ModernEditorCanvas
+              campaign={campaign}
+              previewDevice={previewDevice}
+              gameSize={campaign.gameSize}
+              gamePosition={campaign.gamePosition}
+              onFreeTextZonesChange={(zones) =>
+                setCampaign((prev: any) => ({ ...prev, freeTextZones: zones }))
+              }
+            />
           </div>
         </div>
       </div>

--- a/supabase/migrations/20250602000001_add_free_text_zones.sql
+++ b/supabase/migrations/20250602000001_add_free_text_zones.sql
@@ -1,0 +1,10 @@
+-- Add free_text_zones column to campaigns
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'campaigns' AND column_name = 'free_text_zones'
+    ) THEN
+        ALTER TABLE campaigns ADD COLUMN free_text_zones JSONB DEFAULT '[]'::jsonb;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- store free text zones in the campaign model
- load zones in the editor and propagate changes to campaign state
- persist free text zones when saving a campaign
- add database migration for the new field

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6844abc41414832a91952b1e244ac350