### PR TITLE
Improve preview modals

### DIFF
--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -1,8 +1,7 @@
 
 import React, { useState } from 'react';
 import { X, Monitor, Smartphone, Tablet } from 'lucide-react';
-import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
-import FunnelStandard from '../funnels/FunnelStandard';
+import CampaignPreview from '../CampaignEditor/CampaignPreview';
 
 interface ModernPreviewModalProps {
   isOpen: boolean;
@@ -31,28 +30,14 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
   };
 
   const getContainerStyle = () => {
-    const baseStyle = {
+    return {
       width: '100%',
       height: '100%',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor: campaign.design?.background || '#f9fafb',
-      position: 'relative' as const,
-      overflow: 'auto' as const,
-      padding: '20px'
+      backgroundColor: '#ffffff'
     } as React.CSSProperties;
-
-    if (campaign.design?.backgroundImage) {
-      return {
-        ...baseStyle,
-        backgroundImage: `url(${campaign.design.backgroundImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat'
-      };
-    }
-    return baseStyle;
   };
 
   const enhancedCampaign = {
@@ -80,22 +65,6 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
     }
   };
 
-  const getFunnelComponent = () => {
-    const unlockedTypes = ['wheel', 'scratch', 'jackpot', 'dice'];
-    const funnel =
-      enhancedCampaign.funnel ||
-      (unlockedTypes.includes(enhancedCampaign.type) ? 'unlocked_game' : 'standard');
-    if (funnel === 'unlocked_game') {
-      return (
-        <FunnelUnlockedGame
-          campaign={enhancedCampaign}
-          previewMode={device === 'desktop' ? 'desktop' : device}
-          modalContained={false}
-        />
-      );
-    }
-    return <FunnelStandard campaign={enhancedCampaign} />;
-  };
 
   return (
     <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
@@ -147,15 +116,15 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
               style={getDeviceStyles()}
             >
               <div style={getContainerStyle()}>
-                {campaign.design?.backgroundImage && (
-                  <div className="absolute inset-0 bg-black opacity-20" style={{ zIndex: 1 }} />
-                )}
-                <div
-                  className="relative z-10 w-full h-full"
-                  style={{ minHeight: device === 'desktop' ? '600px' : '100%' }}
-                >
-                  {getFunnelComponent()}
-                </div>
+                <CampaignPreview
+                  campaign={enhancedCampaign}
+                  previewDevice={device}
+                  key={`${device}-${campaign.id}-${JSON.stringify({
+                    gameConfig: enhancedCampaign.gameConfig,
+                    design: enhancedCampaign.design,
+                    screens: enhancedCampaign.screens
+                  })}`}
+                />
               </div>
             </div>
           </div>

--- a/src/components/QuickCampaign/Preview/PreviewContent.tsx
+++ b/src/components/QuickCampaign/Preview/PreviewContent.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
-import FunnelUnlockedGame from '../../funnels/FunnelUnlockedGame';
-import FunnelStandard from '../../funnels/FunnelStandard';
+import CampaignPreview from '../../CampaignEditor/CampaignPreview';
 
 interface PreviewContentProps {
   selectedDevice: 'desktop' | 'tablet' | 'mobile';
@@ -30,8 +29,6 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
   customColors,
   jackpotColors
 }) => {
-  const unlockedTypes = ['wheel', 'scratch', 'jackpot', 'dice'];
-
   // Enhanced campaign with custom colors and proper configuration
   const enhancedCampaign = {
     ...mockCampaign,
@@ -62,58 +59,16 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
     }
   };
 
-  const getFunnelComponent = () => {
-    const funnel = enhancedCampaign.funnel || (unlockedTypes.includes(selectedGameType) ? 'unlocked_game' : 'standard');
-    if (funnel === 'unlocked_game') {
-      return (
-        <FunnelUnlockedGame
-          campaign={enhancedCampaign}
-          previewMode={selectedDevice === 'desktop' ? 'desktop' : selectedDevice}
-          modalContained={false}
-        />
-      );
-    }
-    return (
-      <FunnelStandard
-        campaign={enhancedCampaign}
-        key={JSON.stringify({
-          gameConfig: enhancedCampaign.gameConfig,
-          design: enhancedCampaign.design,
-          screens: enhancedCampaign.screens,
-          customColors: customColors
-        })}
-      />
-    );
-  };
 
   const getContainerStyle = () => {
-    const baseStyle = {
+    return {
       width: '100%',
       height: '100%',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      backgroundColor: enhancedCampaign.design?.background || '#f9fafb',
-      position: 'relative' as const,
-      overflow: 'hidden' as const
-    };
-
-    const mobileBg = enhancedCampaign.design?.mobileBackgroundImage;
-    const bgImage = selectedDevice === 'mobile' && mobileBg
-      ? mobileBg
-      : enhancedCampaign.design?.backgroundImage;
-
-    if (bgImage) {
-      return {
-        ...baseStyle,
-        backgroundImage: `url(${bgImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat'
-      };
-    }
-
-    return baseStyle;
+      backgroundColor: '#ffffff'
+    } as React.CSSProperties;
   };
 
   const getDeviceContainerStyle = () => {
@@ -151,23 +106,15 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
       <div className="w-full h-full flex items-center justify-center p-4">
         <div style={getDeviceContainerStyle()}>
           <div style={getContainerStyle()}>
-            {/* Background overlay for better contrast if background image exists */}
-            {(selectedDevice === 'mobile'
-              ? enhancedCampaign.design?.mobileBackgroundImage
-              : enhancedCampaign.design?.backgroundImage) && (
-              <div
-                className="absolute inset-0 bg-black opacity-20"
-                style={{ zIndex: 1 }}
-              />
-            )}
-            
-            {/* Content container */}
-            <div 
-              className="relative z-10 w-full h-full flex items-center justify-center p-4"
-              style={{ minHeight: selectedDevice === 'desktop' ? '600px' : '100%' }}
-            >
-              {getFunnelComponent()}
-            </div>
+            <CampaignPreview
+              campaign={enhancedCampaign}
+              previewDevice={selectedDevice}
+              key={`${selectedDevice}-${JSON.stringify({
+                gameConfig: enhancedCampaign.gameConfig,
+                design: enhancedCampaign.design,
+                screens: enhancedCampaign.screens
+              })}`}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- switch `ModernPreviewModal` to use existing `CampaignPreview` component
- simplify `QuickCampaign` preview with `CampaignPreview`

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844c18ac360832a90ee26a3a759e83f