### PR TITLE
Improve preview synchronization

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -59,8 +59,25 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
     <div dangerouslySetInnerHTML={{ __html: design.customHTML }} />
   ) : null;
 
-  // Get custom images for desktop/tablet
+  // Get custom images and texts for desktop/tablet
   const customImages = campaign.design?.customImages || [];
+  const customTexts = campaign.design?.customTexts || [];
+
+  const sizeMap: Record<string, string> = {
+    xs: '10px',
+    sm: '12px',
+    base: '14px',
+    lg: '16px',
+    xl: '18px',
+    '2xl': '20px',
+    '3xl': '24px',
+    '4xl': '28px',
+    '5xl': '32px',
+    '6xl': '36px',
+    '7xl': '48px',
+    '8xl': '60px',
+    '9xl': '72px'
+  };
 
   // Helper function to get device-specific config for elements
   const getElementDeviceConfig = (element: any) => {
@@ -135,7 +152,7 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
         {/* Custom Images for desktop/tablet */}
         {customImages.map((customImage: any) => {
           if (!customImage?.src) return null;
-          
+
           const deviceConfig = getElementDeviceConfig(customImage);
           
           return (
@@ -161,6 +178,41 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
                 }}
                 draggable={false}
               />
+            </div>
+          );
+        })}
+
+        {/* Custom Texts for desktop/tablet */}
+        {customTexts.map((customText: any) => {
+          if (!customText?.enabled) return null;
+
+          const deviceConfig = getElementDeviceConfig(customText);
+
+          return (
+            <div
+              key={`preview-text-${customText.id}`}
+              style={{
+                position: 'absolute',
+                transform: `translate3d(${deviceConfig.x}px, ${deviceConfig.y}px, 0)`,
+                color: customText.color || '#000000',
+                fontFamily: customText.fontFamily || 'Inter, sans-serif',
+                fontSize: sizeMap[customText.size || 'base'] || '14px',
+                fontWeight: customText.bold ? 'bold' : 'normal',
+                fontStyle: customText.italic ? 'italic' : 'normal',
+                textDecoration: customText.underline ? 'underline' : 'none',
+                zIndex: 20,
+                pointerEvents: 'none',
+                ...(customText.showFrame
+                  ? {
+                      backgroundColor: customText.frameColor || '#ffffff',
+                      border: `1px solid ${customText.frameBorderColor || '#e5e7eb'}`,
+                      padding: '4px 8px',
+                      borderRadius: '4px'
+                    }
+                  : {})
+              }}
+            >
+              {customText.text}
             </div>
           );
         })}

--- a/src/components/CampaignEditor/Mobile/MobilePreview.tsx
+++ b/src/components/CampaignEditor/Mobile/MobilePreview.tsx
@@ -25,8 +25,25 @@ const MobilePreview: React.FC<MobilePreviewProps> = ({
   const screenStyle = getScreenStyle(mobileConfig);
   const contentLayoutStyle = getContentLayoutStyle(mobileConfig);
 
-  // Get custom images for mobile
+  // Get custom images and texts for mobile
   const customImages = campaign.design?.customImages || [];
+  const customTexts = campaign.design?.customTexts || [];
+
+  const sizeMap: Record<string, string> = {
+    xs: '10px',
+    sm: '12px',
+    base: '14px',
+    lg: '16px',
+    xl: '18px',
+    '2xl': '20px',
+    '3xl': '24px',
+    '4xl': '28px',
+    '5xl': '32px',
+    '6xl': '36px',
+    '7xl': '48px',
+    '8xl': '60px',
+    '9xl': '72px'
+  };
 
   // Helper function to get mobile-specific config for elements
   const getElementMobileConfig = (element: any) => {
@@ -96,6 +113,41 @@ const MobilePreview: React.FC<MobilePreviewProps> = ({
                 }}
                 draggable={false}
               />
+            </div>
+          );
+        })}
+
+        {/* Custom Texts Layer */}
+        {customTexts.map((customText: any) => {
+          if (!customText?.enabled) return null;
+
+          const mobileCfg = getElementMobileConfig(customText);
+
+          return (
+            <div
+              key={`mobile-text-${customText.id}`}
+              style={{
+                position: 'absolute',
+                transform: `translate3d(${mobileCfg.x}px, ${mobileCfg.y}px, 0)`,
+                color: customText.color || '#000000',
+                fontFamily: customText.fontFamily || 'Inter, sans-serif',
+                fontSize: sizeMap[customText.size || 'base'] || '14px',
+                fontWeight: customText.bold ? 'bold' : 'normal',
+                fontStyle: customText.italic ? 'italic' : 'normal',
+                textDecoration: customText.underline ? 'underline' : 'none',
+                zIndex: 15,
+                pointerEvents: 'none',
+                ...(customText.showFrame
+                  ? {
+                      backgroundColor: customText.frameColor || '#ffffff',
+                      border: `1px solid ${customText.frameBorderColor || '#e5e7eb'}`,
+                      padding: '4px 8px',
+                      borderRadius: '4px'
+                    }
+                  : {})
+              }}
+            >
+              {customText.text}
             </div>
           );
         })}

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -124,7 +124,8 @@ const ModernCampaignEditor: React.FC = () => {
         showFrame: false,
         frameColor: '#ffffff',
         frameBorderColor: '#e5e7eb'
-      }
+      },
+      customTexts: []
     },
     screens: {
       1: {


### PR DESCRIPTION
## Summary
- ensure custom texts and images appear in campaign previews
- render all custom elements on mobile preview
- include default `customTexts` array in modern editor state

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d1545b94832a97d2ba287d9f3873