### PR TITLE
Fix preview modal layout

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -31,15 +31,14 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
   };
 
   const backgroundStyle = backgroundImage ? {
-    position: 'absolute' as const,
-    inset: 0,
-    backgroundImage: `url(${backgroundImage})`,
-    backgroundPosition: 'center',
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'cover',
-    opacity: 0.3,
-    zIndex: 0,
-  } : {};
+      position: 'absolute' as const,
+      inset: 0,
+      backgroundImage: `url(${backgroundImage})`,
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      zIndex: 0,
+    } : {};
 
   const contentWrapperStyle = {
     position: 'relative' as const,
@@ -47,9 +46,6 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
     width: '100%',
     height: '100%',
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '20px',
   };
 
   const customStyles = design?.customCSS ? (


### PR DESCRIPTION
## Summary
- remove extra padding and centering in `CampaignPreview`
- show background image at full opacity so preview and editor match

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845338d9b38832aa762b2c6c2c54d80