### PR TITLE
Fix preview modal dimensions

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -31,15 +31,14 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
   };
 
   const backgroundStyle = backgroundImage ? {
-    position: 'absolute' as const,
-    inset: 0,
-    backgroundImage: `url(${backgroundImage})`,
-    backgroundPosition: 'center',
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'cover',
-    opacity: 0.3,
-    zIndex: 0,
-  } : {};
+      position: 'absolute' as const,
+      inset: 0,
+      backgroundImage: `url(${backgroundImage})`,
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      zIndex: 0,
+    } : {};
 
   const contentWrapperStyle = {
     position: 'relative' as const,
@@ -47,9 +46,6 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
     width: '100%',
     height: '100%',
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '20px',
   };
 
   const customStyles = design?.customCSS ? (

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -53,11 +53,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
       position: 'relative',
       width: '100%',
       height: '100%',
-      backgroundColor: campaign.design?.background || '#ebf4f7',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: '20px'
+      backgroundColor: campaign.design?.background || '#ebf4f7'
     };
 
     if (gameBackgroundImage) {
@@ -78,11 +74,11 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
 
   const renderMobilePreview = () => {
     const specs = selectedDevice === 'tablet'
-      ? { width: 768, height: 1024, borderRadius: 20 }
-      : { width: 375, height: 667, borderRadius: 24 };
+      ? { width: 768, height: 1024, borderRadius: 12 }
+      : { width: 375, height: 812, borderRadius: 20 };
 
     return (
-      <div className="w-full h-full flex items-center justify-center p-4">
+      <div className="w-full h-full flex items-center justify-center">
         <div
           style={{
             width: specs.width,

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -21,11 +21,11 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
   const getDeviceStyles = () => {
     switch (device) {
       case 'mobile':
-        return { width: '375px', height: '667px' };
+        return { width: '375px', height: '812px', borderRadius: '20px', border: '1px solid #e5e7eb' };
       case 'tablet':
-        return { width: '768px', height: '1024px' };
+        return { width: '768px', height: '1024px', borderRadius: '12px', border: '1px solid #e5e7eb' };
       default:
-        return { width: '1200px', height: '800px' };
+        return { width: '100%', height: '100%' };
     }
   };
 
@@ -113,9 +113,9 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
 
         {/* Preview Content */}
         <div className="flex-1 overflow-hidden bg-gray-100">
-          <div className="w-full h-full flex items-center justify-center p-8">
-            <div 
-              className="shadow-2xl rounded-2xl overflow-hidden border border-gray-200"
+          <div className="w-full h-full flex items-center justify-center">
+            <div
+              className="shadow-2xl overflow-hidden"
               style={getDeviceStyles()}
             >
               <div style={getContainerStyle()}>


### PR DESCRIPTION
## Summary
- match preview modal device sizes with editor canvas
- remove extra padding around preview content

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845338d9b38832aa762b2c6c2c54d80