### PR TITLE
Fix preview modal device alignment

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -31,15 +31,14 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
   };
 
   const backgroundStyle = backgroundImage ? {
-    position: 'absolute' as const,
-    inset: 0,
-    backgroundImage: `url(${backgroundImage})`,
-    backgroundPosition: 'center',
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'cover',
-    opacity: 0.3,
-    zIndex: 0,
-  } : {};
+      position: 'absolute' as const,
+      inset: 0,
+      backgroundImage: `url(${backgroundImage})`,
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover',
+      zIndex: 0,
+    } : {};
 
   const contentWrapperStyle = {
     position: 'relative' as const,
@@ -47,9 +46,6 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
     width: '100%',
     height: '100%',
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '20px',
   };
 
   const customStyles = design?.customCSS ? (

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -4,6 +4,7 @@ import { X, Monitor, Tablet, Smartphone } from 'lucide-react';
 import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
 import FunnelStandard from '../funnels/FunnelStandard';
 import CampaignPreview from './CampaignPreview';
+import { PREVIEW_CONTAINER_SPECS } from './Mobile/constants';
 
 interface PreviewModalProps {
   isOpen: boolean;
@@ -53,11 +54,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
       position: 'relative',
       width: '100%',
       height: '100%',
-      backgroundColor: campaign.design?.background || '#ebf4f7',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: '20px'
+      backgroundColor: campaign.design?.background || '#ebf4f7'
     };
 
     if (gameBackgroundImage) {
@@ -78,21 +75,23 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
 
   const renderMobilePreview = () => {
     const specs = selectedDevice === 'tablet'
-      ? { width: 768, height: 1024, borderRadius: 20 }
-      : { width: 375, height: 667, borderRadius: 24 };
+      ? PREVIEW_CONTAINER_SPECS.tablet
+      : PREVIEW_CONTAINER_SPECS.mobile;
+
+    const deviceStyle: React.CSSProperties = {
+      width: specs.width,
+      height: specs.height,
+      backgroundColor: '#1f2937',
+      borderRadius: '24px',
+      padding: '8px',
+      boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+      position: 'relative',
+      overflow: 'hidden'
+    };
 
     return (
-      <div className="w-full h-full flex items-center justify-center p-4">
-        <div
-          style={{
-            width: specs.width,
-            height: specs.height,
-            border: '1px solid #e5e7eb',
-            borderRadius: specs.borderRadius,
-            overflow: 'hidden',
-            backgroundColor: '#ffffff'
-          }}
-        >
+      <div className="w-full h-full flex items-center justify-center">
+        <div style={deviceStyle}>
           <CampaignPreview
             campaign={campaign}
             previewDevice={selectedDevice}

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { X, Monitor, Smartphone, Tablet } from 'lucide-react';
 import CampaignPreview from '../CampaignEditor/CampaignPreview';
+import { PREVIEW_CONTAINER_SPECS } from '../CampaignEditor/Mobile/constants';
 
 interface ModernPreviewModalProps {
   isOpen: boolean;
@@ -21,11 +22,29 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
   const getDeviceStyles = () => {
     switch (device) {
       case 'mobile':
-        return { width: '375px', height: '667px' };
+        return {
+          width: `${PREVIEW_CONTAINER_SPECS.mobile.width}px`,
+          height: `${PREVIEW_CONTAINER_SPECS.mobile.height}px`,
+          backgroundColor: '#1f2937',
+          borderRadius: '24px',
+          padding: '8px',
+          boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+          position: 'relative',
+          overflow: 'hidden'
+        } as React.CSSProperties;
       case 'tablet':
-        return { width: '768px', height: '1024px' };
+        return {
+          width: `${PREVIEW_CONTAINER_SPECS.tablet.width}px`,
+          height: `${PREVIEW_CONTAINER_SPECS.tablet.height}px`,
+          backgroundColor: '#1f2937',
+          borderRadius: '24px',
+          padding: '8px',
+          boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+          position: 'relative',
+          overflow: 'hidden'
+        } as React.CSSProperties;
       default:
-        return { width: '1200px', height: '800px' };
+        return { width: '100%', height: '100%' };
     }
   };
 
@@ -113,9 +132,9 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
 
         {/* Preview Content */}
         <div className="flex-1 overflow-hidden bg-gray-100">
-          <div className="w-full h-full flex items-center justify-center p-8">
-            <div 
-              className="shadow-2xl rounded-2xl overflow-hidden border border-gray-200"
+          <div className="w-full h-full flex items-center justify-center">
+            <div
+              className="shadow-2xl overflow-hidden"
               style={getDeviceStyles()}
             >
               <div style={getContainerStyle()}>


### PR DESCRIPTION
## Summary
- sync preview modal device sizes with editor constants
- apply matching device frame styles for mobile and tablet previews

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845338d9b38832aa762b2c6c2c54d80