### PR TITLE
Improve preview sync and element drag performance

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -153,7 +153,7 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
         
         {/* Custom Images for desktop/tablet - render with exact same logic as editor */}
         {customImages.map((customImage: any, idx: number) => {
-          if (!customImage?.src) return null;
+          if (!customImage?.src || customImage.enabled === false) return null;
 
           const deviceConfig = getElementDeviceConfig(customImage);
 

--- a/src/components/CampaignEditor/Mobile/MobilePreview.tsx
+++ b/src/components/CampaignEditor/Mobile/MobilePreview.tsx
@@ -86,7 +86,7 @@ const MobilePreview: React.FC<MobilePreviewProps> = ({
 
         {/* Custom Images Layer - render with exact same logic as desktop */}
         {customImages.map((customImage: any, idx: number) => {
-          if (!customImage?.src) return null;
+          if (!customImage?.src || customImage.enabled === false) return null;
           
           const mobileConfig = getElementMobileConfig(customImage);
           

--- a/src/components/ModernEditor/TextElement.tsx
+++ b/src/components/ModernEditor/TextElement.tsx
@@ -56,6 +56,7 @@ const TextElement: React.FC<TextElementProps> = ({
     fontStyle: element.italic ? 'italic' : 'normal',
     textDecoration: element.underline ? 'underline' : 'none',
     fontFamily: element.fontFamily || 'Inter, sans-serif',
+    lineHeight: 1,
     cursor: isDragging ? 'grabbing' : 'grab',
     userSelect: 'none',
     willChange: isDragging ? 'transform' : 'auto',

--- a/src/components/ModernEditor/hooks/useImageElementDrag.ts
+++ b/src/components/ModernEditor/hooks/useImageElementDrag.ts
@@ -8,7 +8,8 @@ export const useImageElementDrag = (
   onUpdate: (updates: any) => void
 ) => {
   const [isDragging, setIsDragging] = useState(false);
-  const dragStartRef = useRef<{offsetX: number, offsetY: number} | null>(null);
+  const dragStartRef = useRef<{ offsetX: number; offsetY: number } | null>(null);
+  const frameRef = useRef<number | null>(null);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -25,18 +26,20 @@ export const useImageElementDrag = (
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       if (!containerRef.current || !dragStartRef.current) return;
-      
+
       const containerRect = containerRef.current.getBoundingClientRect();
-      
+
       let newX = moveEvent.clientX - containerRect.left - dragStartRef.current.offsetX;
       let newY = moveEvent.clientY - containerRect.top - dragStartRef.current.offsetY;
-      
+
       // Constrain to container bounds
       newX = Math.max(0, Math.min(newX, containerRect.width - deviceConfig.width));
       newY = Math.max(0, Math.min(newY, containerRect.height - deviceConfig.height));
-      
-      // Update immediately for real-time feedback
-      onUpdate({ x: newX, y: newY });
+
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+      frameRef.current = requestAnimationFrame(() => {
+        onUpdate({ x: newX, y: newY });
+      });
     };
 
     const handleMouseUp = () => {

--- a/src/components/ModernEditor/hooks/useImageElementResize.ts
+++ b/src/components/ModernEditor/hooks/useImageElementResize.ts
@@ -17,6 +17,8 @@ export const useImageElementResize = (
     aspectRatio: number
   } | null>(null);
 
+  const frameRef = useRef<number | null>(null);
+
   const handleResizeStart = useCallback((e: React.MouseEvent, direction: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -86,7 +88,10 @@ export const useImageElementResize = (
       newWidth = Math.min(newWidth, containerRect.width - deviceConfig.x);
       newHeight = Math.min(newHeight, containerRect.height - deviceConfig.y);
 
-      onUpdate({ width: newWidth, height: newHeight });
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+      frameRef.current = requestAnimationFrame(() => {
+        onUpdate({ width: newWidth, height: newHeight });
+      });
     };
 
     const handleMouseUp = () => {

--- a/src/components/ModernEditor/hooks/useTextElementDrag.ts
+++ b/src/components/ModernEditor/hooks/useTextElementDrag.ts
@@ -8,7 +8,8 @@ export const useTextElementDrag = (
   onUpdate: (updates: any) => void
 ) => {
   const [isDragging, setIsDragging] = useState(false);
-  const dragStartRef = useRef<{offsetX: number, offsetY: number} | null>(null);
+  const dragStartRef = useRef<{ offsetX: number; offsetY: number } | null>(null);
+  const frameRef = useRef<number | null>(null);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -25,20 +26,22 @@ export const useTextElementDrag = (
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       if (!containerRef.current || !dragStartRef.current) return;
-      
+
       const containerRect = containerRef.current.getBoundingClientRect();
       const elementWidth = elementRef.current?.offsetWidth || 0;
       const elementHeight = elementRef.current?.offsetHeight || 0;
-      
+
       let newX = moveEvent.clientX - containerRect.left - dragStartRef.current.offsetX;
       let newY = moveEvent.clientY - containerRect.top - dragStartRef.current.offsetY;
-      
+
       // Constrain to container bounds
       newX = Math.max(0, Math.min(newX, containerRect.width - elementWidth));
       newY = Math.max(0, Math.min(newY, containerRect.height - elementHeight));
-      
-      // Update immediately for real-time feedback
-      onUpdate({ x: newX, y: newY });
+
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+      frameRef.current = requestAnimationFrame(() => {
+        onUpdate({ x: newX, y: newY });
+      });
     };
 
     const handleMouseUp = () => {


### PR DESCRIPTION
## Summary
- smooth drag and resize interactions with `requestAnimationFrame`
- ignore disabled images in previews
- fix text line height for consistent layout

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68453dc3aabc832aba31c9fe2c0f3fc8