### PR TITLE
Update preview containers to match background image size

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
 import FunnelStandard from '../funnels/FunnelStandard';
 import MobilePreview from './Mobile/MobilePreview';
@@ -27,12 +27,26 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
   const mobileBackground = design?.mobileBackgroundImage;
   const backgroundImage = previewDevice === 'mobile' && mobileBackground ? mobileBackground : baseBackground;
 
+  const [imageDims, setImageDims] = useState({ width: 1080, height: 1920 });
+
+  useEffect(() => {
+    if (!backgroundImage) {
+      setImageDims({ width: 1080, height: 1920 });
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      setImageDims({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.src = backgroundImage;
+  }, [backgroundImage]);
+
   // Use identical container styling as the editor canvas
   const containerStyle = {
-    width: '100%',
-    height: '100%',
+    width: `${imageDims.width}px`,
+    height: `${imageDims.height}px`,
     position: 'relative' as const,
-    overflow: 'hidden',
+    overflow: 'auto',
     backgroundColor: design?.background || '#f8fafc',
     // Ensure no default margins/padding that could affect positioning
     margin: 0,
@@ -46,7 +60,7 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
       backgroundImage: `url(${backgroundImage})`,
       backgroundPosition: 'center',
       backgroundRepeat: 'no-repeat',
-      backgroundSize: 'cover',
+      backgroundSize: 'contain',
       zIndex: 0,
     } : {};
 

--- a/src/components/CampaignEditor/Mobile/MobilePreview.tsx
+++ b/src/components/CampaignEditor/Mobile/MobilePreview.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import MobileWheelPreview from '../../GameTypes/MobileWheelPreview';
 import MobileButton from './MobileButton';
 import MobileContent from './MobileContent';
@@ -21,8 +21,24 @@ const MobilePreview: React.FC<MobilePreviewProps> = ({
   const verticalOffset = mobileConfig.gameVerticalOffset || 0;
   const horizontalOffset = mobileConfig.gameHorizontalOffset || 0;
 
-  const deviceStyle = getDeviceStyle();
-  const screenStyle = getScreenStyle(mobileConfig);
+  const bgImage =
+    mobileConfig.backgroundImage || campaign.design?.mobileBackgroundImage;
+  const [imageDims, setImageDims] = useState({ width: 1080, height: 1920 });
+
+  useEffect(() => {
+    if (!bgImage) {
+      setImageDims({ width: 1080, height: 1920 });
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      setImageDims({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.src = bgImage;
+  }, [bgImage]);
+
+  const deviceStyle = getDeviceStyle(imageDims);
+  const screenStyle = getScreenStyle(mobileConfig, imageDims);
   const contentLayoutStyle = getContentLayoutStyle(mobileConfig);
 
   // Get custom images and texts for mobile with proper fallback

--- a/src/components/CampaignEditor/Mobile/styles.ts
+++ b/src/components/CampaignEditor/Mobile/styles.ts
@@ -1,9 +1,9 @@
 
 import { PREVIEW_CONTAINER_SPECS, MOBILE_FORMAT_SPECS } from './constants';
 
-export const getDeviceStyle = () => ({
-  width: PREVIEW_CONTAINER_SPECS.mobile.width,
-  height: PREVIEW_CONTAINER_SPECS.mobile.height,
+export const getDeviceStyle = (dims?: { width: number; height: number }) => ({
+  width: dims?.width || PREVIEW_CONTAINER_SPECS.mobile.width,
+  height: dims?.height || PREVIEW_CONTAINER_SPECS.mobile.height,
   backgroundColor: '#1f2937',
   borderRadius: '24px',
   padding: '8px',
@@ -12,7 +12,10 @@ export const getDeviceStyle = () => ({
   overflow: 'hidden'
 });
 
-export const getScreenStyle = (mobileConfig: any) => ({
+export const getScreenStyle = (
+  mobileConfig: any,
+  dims?: { width: number; height: number }
+) => ({
   width: '100%',
   height: '100%',
   backgroundColor: mobileConfig.backgroundColor || '#ebf4f7',
@@ -23,8 +26,8 @@ export const getScreenStyle = (mobileConfig: any) => ({
   borderRadius: '16px',
   position: 'relative' as const,
   overflow: 'hidden',
-  // Ensure proper aspect ratio for 1080×1920px content
-  aspectRatio: `${MOBILE_FORMAT_SPECS.width} / ${MOBILE_FORMAT_SPECS.height}`
+  aspectRatio: `${dims?.width || MOBILE_FORMAT_SPECS.width} / ${dims?.height ||
+    MOBILE_FORMAT_SPECS.height}`
 });
 
 export const getContentLayoutStyle = (mobileConfig: any) => {

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { X, Monitor, Tablet, Smartphone } from 'lucide-react';
 import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
 import FunnelStandard from '../funnels/FunnelStandard';
@@ -11,22 +11,25 @@ interface PreviewModalProps {
   campaign: any;
 }
 
-// Define container specs directly to avoid import issues
-const PREVIEW_CONTAINER_SPECS = {
-  mobile: {
-    width: 375,
-    height: 667,
-    scale: 1
-  },
-  tablet: {
-    width: 768,
-    height: 1024,
-    scale: 0.8
-  }
-};
-
 const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }) => {
   const [selectedDevice, setSelectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+  const [imageDims, setImageDims] = useState({ width: 1080, height: 1920 });
+
+  useEffect(() => {
+    let imgSrc = campaign.design?.backgroundImage;
+    if (selectedDevice === 'mobile') {
+      imgSrc = campaign.design?.mobileBackgroundImage || imgSrc;
+    }
+    const img = new Image();
+    if (!imgSrc) {
+      setImageDims({ width: 1080, height: 1920 });
+      return;
+    }
+    img.onload = () => {
+      setImageDims({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.src = imgSrc;
+  }, [campaign.design?.backgroundImage, campaign.design?.mobileBackgroundImage, selectedDevice]);
 
   if (!isOpen) return null;
 
@@ -85,14 +88,9 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
   );
 
   const renderMobilePreview = () => {
-    // Synchronisé avec PREVIEW_CONTAINER_SPECS
-    const specs = selectedDevice === 'tablet'
-      ? PREVIEW_CONTAINER_SPECS.tablet
-      : PREVIEW_CONTAINER_SPECS.mobile;
-
     const deviceStyle: React.CSSProperties = {
-      width: specs.width,
-      height: specs.height,
+      width: imageDims.width,
+      height: imageDims.height,
       backgroundColor: '#1f2937',
       borderRadius: '16px',
       padding: '8px',

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { X, Monitor, Smartphone, Tablet } from 'lucide-react';
 import CampaignPreview from '../CampaignEditor/CampaignPreview';
 
@@ -9,35 +9,37 @@ interface ModernPreviewModalProps {
   campaign: any;
 }
 
-// Define container specs directly to avoid import issues
-const PREVIEW_CONTAINER_SPECS = {
-  mobile: {
-    width: 375,
-    height: 667,
-    scale: 1
-  },
-  tablet: {
-    width: 768,
-    height: 1024,
-    scale: 0.8
-  }
-};
-
 const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
   isOpen,
   onClose,
   campaign
 }) => {
   const [device, setDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+  const [imageDims, setImageDims] = useState({ width: 1080, height: 1920 });
+
+  useEffect(() => {
+    let imgSrc = campaign.design?.backgroundImage;
+    if (device === 'mobile') {
+      imgSrc = campaign.design?.mobileBackgroundImage || imgSrc;
+    }
+    const img = new Image();
+    if (!imgSrc) {
+      setImageDims({ width: 1080, height: 1920 });
+      return;
+    }
+    img.onload = () => {
+      setImageDims({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.src = imgSrc;
+  }, [campaign.design?.backgroundImage, campaign.design?.mobileBackgroundImage, device]);
 
   if (!isOpen) return null;
 
   const getDeviceStyles = () => {
     if (device === 'mobile' || device === 'tablet') {
-      const specs = PREVIEW_CONTAINER_SPECS[device];
       return {
-        width: `${specs.width}px`,
-        height: `${specs.height}px`,
+        width: `${imageDims.width}px`,
+        height: `${imageDims.height}px`,
         backgroundColor: '#1f2937',
         borderRadius: '16px',
         padding: '8px',


### PR DESCRIPTION
## Summary
- compute background image dimensions for previews
- scale preview containers to exact image size
- adjust preview modals to respect dynamic dimensions
- fallback to default dimensions when no image is present

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845d6f89024832a9795bfc3587a6a37