### PR TITLE
Fix preview background images

### DIFF
--- a/src/components/CampaignEditor/Mobile/styles.ts
+++ b/src/components/CampaignEditor/Mobile/styles.ts
@@ -20,12 +20,12 @@ export const getScreenStyle = (
   height: '100%',
   backgroundColor: mobileConfig.backgroundColor || '#ebf4f7',
   backgroundImage: mobileConfig.backgroundImage ? `url(${mobileConfig.backgroundImage})` : undefined,
-  backgroundSize: mobileConfig.backgroundMode === 'contain' ? 'contain' : 'cover',
+  backgroundSize: 'contain',
   backgroundPosition: 'center',
   backgroundRepeat: 'no-repeat',
   borderRadius: '16px',
   position: 'relative' as const,
-  overflow: 'hidden',
+  overflow: 'auto',
   aspectRatio: `${dims?.width || MOBILE_FORMAT_SPECS.width} / ${dims?.height ||
     MOBILE_FORMAT_SPECS.height}`
 });

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -74,7 +74,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
     };
     if (gameBackgroundImage) {
       style.backgroundImage = `url(${gameBackgroundImage})`;
-      style.backgroundSize = 'cover';
+      style.backgroundSize = 'contain';
       style.backgroundPosition = 'center';
       style.backgroundRepeat = 'no-repeat';
     }
@@ -118,7 +118,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
-      <div className="bg-white w-full h-full flex flex-col relative overflow-hidden">
+      <div className="bg-white w-full h-full flex flex-col relative overflow-auto">
         <div className="absolute top-0 left-0 right-0 z-20 flex items-center justify-between px-6 py-4 bg-white border-b border-gray-200 shadow-sm">
           <div className="flex items-center space-x-4">
             <h2 className="text-lg font-semibold text-gray-800">Aperçu de la campagne</h2>

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -45,7 +45,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
         padding: '8px',
         boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25)',
         position: 'relative',
-        overflow: 'hidden',
+        overflow: 'auto',
         // Ensure consistent box model
         boxSizing: 'border-box',
         margin: 0
@@ -105,7 +105,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className="bg-white w-full h-full flex flex-col relative overflow-hidden rounded-3xl shadow-2xl max-w-7xl max-h-[90vh]">
+      <div className="bg-white w-full h-full flex flex-col relative overflow-auto rounded-3xl shadow-2xl max-w-7xl max-h-screen">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b bg-white">
           <div className="flex items-center space-x-4">
@@ -146,10 +146,10 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
         </div>
 
         {/* Preview Content */}
-        <div className="flex-1 overflow-hidden bg-gray-100">
+        <div className="flex-1 overflow-auto bg-gray-100">
           <div className="w-full h-full flex items-center justify-center">
             <div
-              className="shadow-2xl overflow-hidden"
+              className="shadow-2xl overflow-auto"
               style={getDeviceStyles()}
             >
               <div style={getContainerStyle()}>

--- a/src/components/QuickCampaign/CampaignPreviewModal.tsx
+++ b/src/components/QuickCampaign/CampaignPreviewModal.tsx
@@ -35,7 +35,7 @@ const CampaignPreviewModal: React.FC<CampaignPreviewModalProps> = ({
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.9 }}
-        className="bg-white w-full h-full flex flex-col relative overflow-hidden rounded-3xl shadow-2xl max-w-7xl max-h-[90vh]"
+        className="bg-white w-full h-full flex flex-col relative overflow-auto rounded-3xl shadow-2xl max-w-7xl max-h-screen"
       >
         <PreviewHeader
           campaignName={campaignName}

--- a/src/components/QuickCampaign/Preview/PreviewContent.tsx
+++ b/src/components/QuickCampaign/Preview/PreviewContent.tsx
@@ -72,32 +72,21 @@ const PreviewContent: React.FC<PreviewContentProps> = ({
   };
 
   const getDeviceContainerStyle = () => {
+    const base = {
+      margin: '0 auto',
+      backgroundColor: '#ffffff',
+      overflow: 'auto' as const,
+      width: 'fit-content',
+      height: 'fit-content'
+    };
+
     switch (selectedDevice) {
       case 'tablet':
-        return {
-          maxWidth: '768px',
-          maxHeight: '1024px',
-          margin: '0 auto',
-          border: '1px solid #e5e7eb',
-          borderRadius: '12px',
-          overflow: 'hidden' as const,
-          backgroundColor: '#ffffff'
-        };
+        return { ...base, border: '1px solid #e5e7eb', borderRadius: '12px' };
       case 'mobile':
-        return {
-          maxWidth: '375px',
-          maxHeight: '812px',
-          margin: '0 auto',
-          border: '1px solid #e5e7eb',
-          borderRadius: '20px',
-          overflow: 'hidden' as const,
-          backgroundColor: '#ffffff'
-        };
+        return { ...base, border: '1px solid #e5e7eb', borderRadius: '20px' };
       default:
-        return {
-          width: '100%',
-          height: '100%'
-        };
+        return { ...base, width: '100%', height: '100%' };
     }
   };
 


### PR DESCRIPTION
## Summary
- display preview backgrounds in full without cropping
- allow preview modals to scroll if content is larger than viewport

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e1bbb730832aa139040039a54eca