### PR TITLE
Fix identical preview rendering in preview modal

### DIFF
--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -83,7 +83,15 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
 
   const renderDesktopPreview = () => (
     <div style={getBackgroundStyle()}>
-      {getPreviewFunnel()}
+      <CampaignPreview
+        campaign={campaign}
+        previewDevice="desktop"
+        key={`desktop-${campaign.id}-${JSON.stringify({
+          gameConfig: campaign.gameConfig,
+          design: campaign.design,
+          screens: campaign.screens
+        })}`}
+      />
     </div>
   );
 


### PR DESCRIPTION
## Summary
- ensure desktop mode uses the same CampaignPreview component as mobile/tablet

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eafe70b8832aa516da2b9f4fe236