### PR TITLE
Fix tablet preview cropping

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -42,16 +42,19 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
   }, [backgroundImage]);
 
   // Use identical container styling as the editor canvas
-  const containerStyle = {
-    width: `${imageDims.width}px`,
-    height: `${imageDims.height}px`,
-    position: 'relative' as const,
+  const containerStyle: React.CSSProperties = {
+    width: '100%',
+    maxWidth: imageDims.width,
+    height: 'auto',
+    maxHeight: imageDims.height,
+    aspectRatio: `${imageDims.width} / ${imageDims.height}`,
+    position: 'relative',
     overflow: 'auto',
     backgroundColor: design?.background || '#f8fafc',
     // Ensure no default margins/padding that could affect positioning
     margin: 0,
     padding: 0,
-    boxSizing: 'border-box' as const
+    boxSizing: 'border-box'
   };
 
   const backgroundStyle = backgroundImage ? {

--- a/src/components/CampaignEditor/Mobile/styles.ts
+++ b/src/components/CampaignEditor/Mobile/styles.ts
@@ -2,14 +2,18 @@
 import { PREVIEW_CONTAINER_SPECS, MOBILE_FORMAT_SPECS } from './constants';
 
 export const getDeviceStyle = (dims?: { width: number; height: number }) => ({
-  width: dims?.width || PREVIEW_CONTAINER_SPECS.mobile.width,
-  height: dims?.height || PREVIEW_CONTAINER_SPECS.mobile.height,
+  width: '100%',
+  maxWidth: dims?.width || PREVIEW_CONTAINER_SPECS.mobile.width,
+  height: 'auto',
+  maxHeight: dims?.height || PREVIEW_CONTAINER_SPECS.mobile.height,
+  aspectRatio: `${dims?.width || PREVIEW_CONTAINER_SPECS.mobile.width} / ${
+    dims?.height || PREVIEW_CONTAINER_SPECS.mobile.height}`,
   backgroundColor: '#1f2937',
   borderRadius: '24px',
   padding: '8px',
   boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
   position: 'relative' as const,
-  overflow: 'hidden'
+  overflow: 'auto'
 });
 
 export const getScreenStyle = (

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -97,18 +97,21 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
 
   const renderMobilePreview = () => {
     const deviceStyle: React.CSSProperties = {
-      width: imageDims.width,
-      height: imageDims.height,
+      width: '100%',
+      maxWidth: imageDims.width,
+      height: 'auto',
+      maxHeight: imageDims.height,
+      aspectRatio: `${imageDims.width} / ${imageDims.height}`,
       backgroundColor: '#1f2937',
       borderRadius: '16px',
       padding: '8px',
       boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
       position: 'relative',
-      overflow: 'hidden'
+      overflow: 'auto'
     };
 
     return (
-      <div className="w-full h-full flex items-center justify-center">
+      <div className="w-full h-full flex items-center justify-center overflow-auto">
         <div style={deviceStyle}>
           <CampaignPreview
             campaign={campaign}


### PR DESCRIPTION
## Summary
- improve responsive scaling in CampaignPreview
- adjust PreviewModal tablet/mobile view styling
- make mobile preview device style responsive

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845ff63226c832ab88802abfb6545f9