### PR TITLE
Add brand style helper for wheel

### DIFF
--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -4,6 +4,7 @@ import { Jackpot } from '../../GameTypes';
 import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import FormPreview from '../../GameTypes/FormPreview';
+import { applyBrandStyleToWheel, BrandColors } from '../../../utils/BrandStyleAnalyzer';
 
 interface GameRendererProps {
   gameType: string;
@@ -22,6 +23,8 @@ interface GameRendererProps {
     slotBorderWidth: number;
     slotBackgroundColor: string;
   };
+  logoUrl?: string;
+  fontUrl?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
@@ -32,36 +35,29 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   mockCampaign,
   customColors,
   jackpotColors,
+  logoUrl,
+  fontUrl,
   gameSize = 'large',
   gamePosition = 'center',
   previewDevice = 'desktop'
 }) => {
-  // Synchroniser les couleurs de la roue avec les couleurs personnalisées
-  const synchronizedCampaign = {
-    ...mockCampaign,
-    config: {
-      ...mockCampaign.config,
-      roulette: {
-        ...mockCampaign.config?.roulette,
-        borderColor: customColors.primary,
-        borderOutlineColor: customColors.accent || customColors.secondary,
-        segmentColor1: customColors.primary,
-        segmentColor2: customColors.secondary,
-        segments: mockCampaign.config?.roulette?.segments?.map((segment: any, index: number) => ({
-          ...segment,
-          color: index % 2 === 0 ? customColors.primary : customColors.secondary
-        })) || []
-      }
-    },
-    design: {
-      ...mockCampaign.design,
-      customColors: customColors
-    },
-    buttonConfig: {
-      ...mockCampaign.buttonConfig,
-      color: customColors.primary,
-      borderColor: customColors.primary
+  React.useEffect(() => {
+    if (fontUrl) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+      return () => {
+        document.head.removeChild(link);
+      };
     }
+  }, [fontUrl]);
+
+  // Appliquer la charte de marque à la configuration de la roue
+  const synchronizedCampaign = applyBrandStyleToWheel(mockCampaign, customColors as BrandColors);
+  synchronizedCampaign.design = {
+    ...synchronizedCampaign.design,
+    centerLogo: logoUrl || synchronizedCampaign.design?.centerLogo,
   };
 
   // Style universel pour tout centrer verticalement et horizontalement

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -18,6 +18,8 @@ const Step3VisualStyle: React.FC = () => {
     launchDate,
     marketingGoal,
     logoFile,
+    logoUrl,
+    fontUrl,
     selectedTheme,
     backgroundImage,
     customColors,
@@ -232,7 +234,17 @@ const Step3VisualStyle: React.FC = () => {
               <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-3xl shadow-inner border border-gray-200/50 max-w-2xl w-full flex items-center justify-center min-h-[400px] p-8">
                 {selectedGameType === 'jackpot' ? <JackpotPreview customColors={customColors} jackpotColors={jackpotColors} /> : <div className="flex flex-col items-center justify-center w-full h-full">
                     <div className="transform scale-90 origin-center">
-                      <GameRenderer gameType={selectedGameType || 'wheel'} mockCampaign={previewCampaign} customColors={customColors} jackpotColors={jackpotColors} gameSize="medium" gamePosition="center" previewDevice="desktop" />
+                      <GameRenderer
+                        gameType={selectedGameType || 'wheel'}
+                        mockCampaign={previewCampaign}
+                        customColors={customColors}
+                        jackpotColors={jackpotColors}
+                        logoUrl={logoUrl || undefined}
+                        fontUrl={fontUrl || undefined}
+                        gameSize="medium"
+                        gamePosition="center"
+                        previewDevice="desktop"
+                      />
                     </div>
                   </div>}
               </div>

--- a/src/stores/quickCampaignStore.ts
+++ b/src/stores/quickCampaignStore.ts
@@ -7,6 +7,9 @@ export interface QuickCampaignState {
   launchDate: string;
   marketingGoal: string;
   logoFile: File | null;
+  brandSiteUrl: string;
+  logoUrl: string | null;
+  fontUrl: string | null;
   selectedTheme: string;
   backgroundImage: File | null;
   segmentCount: number;
@@ -30,6 +33,9 @@ export interface QuickCampaignState {
   setLaunchDate: (date: string) => void;
   setMarketingGoal: (goal: string) => void;
   setLogoFile: (file: File | null) => void;
+  setBrandSiteUrl: (url: string) => void;
+  setLogoUrl: (url: string | null) => void;
+  setFontUrl: (url: string | null) => void;
   setSelectedTheme: (theme: string) => void;
   setBackgroundImage: (file: File | null) => void;
   setSegmentCount: (count: number) => void;
@@ -46,6 +52,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
   launchDate: '',
   marketingGoal: '',
   logoFile: null,
+  brandSiteUrl: '',
+  logoUrl: null,
+  fontUrl: null,
   selectedTheme: 'default',
   backgroundImage: null,
   segmentCount: 4,
@@ -71,6 +80,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
   setLaunchDate: (date) => set({ launchDate: date }),
   setMarketingGoal: (goal) => set({ marketingGoal: goal }),
   setLogoFile: (file) => set({ logoFile: file }),
+  setBrandSiteUrl: (url) => set({ brandSiteUrl: url }),
+  setLogoUrl: (url) => set({ logoUrl: url }),
+  setFontUrl: (url) => set({ fontUrl: url }),
   setSelectedTheme: (theme) => set({ selectedTheme: theme }),
   setBackgroundImage: (file) => set({ backgroundImage: file }),
   setSegmentCount: (count) => set({ segmentCount: count }),
@@ -86,7 +98,7 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
       type: state.selectedGameType || 'wheel',
       design: {
         customColors: state.customColors,
-        centerLogo: null,
+        centerLogo: state.logoUrl || null,
         mobileBackgroundImage: null
       },
       buttonConfig: {
@@ -164,6 +176,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
     launchDate: '',
     marketingGoal: '',
     logoFile: null,
+    brandSiteUrl: '',
+    logoUrl: null,
+    fontUrl: null,
     selectedTheme: 'default',
     backgroundImage: null,
     segmentCount: 4,

--- a/src/utils/BrandStyleAnalyzer.ts
+++ b/src/utils/BrandStyleAnalyzer.ts
@@ -1,0 +1,75 @@
+export interface BrandStyle {
+  primaryColor: string;
+  logoUrl?: string;
+  fontUrl?: string;
+  faviconUrl?: string;
+  secondaryColor?: string;
+  lightColor?: string;
+  darkColor?: string;
+}
+
+export async function analyzeBrandStyle(siteUrl: string): Promise<BrandStyle> {
+  const apiUrl = `https://api.microlink.io/?url=${encodeURIComponent(siteUrl)}&palette=true&meta=true&screenshot=false`;
+  const res = await fetch(apiUrl);
+  if (!res.ok) {
+    throw new Error('Microlink request failed');
+  }
+  const json = await res.json();
+  const data = json.data || {};
+  const palette = data.palette || {};
+  const primaryColor =
+    palette?.vibrant?.background ||
+    palette?.lightVibrant?.background ||
+    palette?.darkVibrant?.background ||
+    '#841b60';
+
+  return {
+    primaryColor,
+    logoUrl: data.logo?.url,
+    fontUrl: data.font?.url,
+    faviconUrl: data.favicon?.url,
+    secondaryColor: palette?.lightMuted?.background,
+    lightColor: palette?.lightVibrant?.background,
+    darkColor: palette?.darkVibrant?.background,
+  };
+}
+
+export interface BrandColors {
+  primary: string;
+  secondary: string;
+  accent?: string;
+}
+
+// Central helper to apply a brand color scheme to a wheel configuration
+export function applyBrandStyleToWheel(campaign: any, colors: BrandColors) {
+  const updatedSegments = (campaign?.config?.roulette?.segments || []).map(
+    (segment: any, index: number) => ({
+      ...segment,
+      color: segment.color || (index % 2 === 0 ? colors.primary : colors.secondary)
+    })
+  );
+
+  return {
+    ...campaign,
+    config: {
+      ...campaign.config,
+      roulette: {
+        ...(campaign.config?.roulette || {}),
+        borderColor: colors.primary,
+        borderOutlineColor: colors.accent || colors.secondary || colors.primary,
+        segmentColor1: colors.primary,
+        segmentColor2: colors.secondary,
+        segments: updatedSegments
+      }
+    },
+    design: {
+      ...(campaign.design || {}),
+      customColors: colors
+    },
+    buttonConfig: {
+      ...(campaign.buttonConfig || {}),
+      color: colors.accent || colors.primary,
+      borderColor: colors.primary
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add `applyBrandStyleToWheel` helper in BrandStyleAnalyzer
- use the helper in GameRenderer to apply brand colors to wheel config

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a4567d98832a9fba5b4ce8d06388