### PR TITLE
Improve brand style extraction

### DIFF
--- a/src/components/GameTypes/WheelComponents/WheelButton.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelButton.tsx
@@ -7,6 +7,7 @@ interface ButtonConfig {
   size: 'small' | 'medium' | 'large';
   text: string;
   visible: boolean;
+  textColor?: string;
 }
 interface WheelButtonProps {
   buttonConfig: ButtonConfig;
@@ -39,8 +40,9 @@ const WheelButton: React.FC<WheelButtonProps> = ({
     borderWidth: `${buttonConfig.borderWidth}px`,
     borderRadius: `${buttonConfig.borderRadius}px`,
     borderStyle: 'solid',
-    boxShadow: `0 4px 15px ${buttonConfig.borderColor}30, inset 0 1px 0 rgba(255, 255, 255, 0.2)`
-  }} className={`${getButtonSizeClasses()} text-white font-bold disabled:opacity-50 hover:opacity-90 transition-all duration-200 relative overflow-hidden`}>
+    boxShadow: `0 4px 15px ${buttonConfig.borderColor}30, inset 0 1px 0 rgba(255, 255, 255, 0.2)`,
+    color: buttonConfig.textColor || '#ffffff'
+  }} className={`${getButtonSizeClasses()} font-bold disabled:opacity-50 hover:opacity-90 transition-all duration-200 relative overflow-hidden`}>
       <span className="relative z-10">
         {spinning ? 'Tourne...' : formValidated ? 'Lancer la roue' : buttonConfig.text || 'Remplir le formulaire'}
       </span>

--- a/src/components/GameTypes/WheelComponents/WheelPreviewConfig.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewConfig.tsx
@@ -9,9 +9,10 @@ export const getWheelPreviewConfig = (campaign: any) => {
   const borderOutlineColor = campaign?.config?.roulette?.borderOutlineColor || '#FFD700';
   
   const customColors = campaign?.design?.customColors;
-  
+
   const buttonConfig = campaign?.buttonConfig || {
     color: customColors?.primary || '#841b60',
+    textColor: customColors?.accent || '#ffffff',
     borderColor: customColors?.primary || '#841b60',
     borderWidth: 1,
     borderRadius: 8,

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -4,6 +4,7 @@ import { Jackpot } from '../../GameTypes';
 import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import FormPreview from '../../GameTypes/FormPreview';
+import { applyBrandColorsToVisualStyle, BrandColors } from '../../../utils/BrandStyleAnalyzer';
 
 interface GameRendererProps {
   gameType: string;
@@ -22,6 +23,8 @@ interface GameRendererProps {
     slotBorderWidth: number;
     slotBackgroundColor: string;
   };
+  logoUrl?: string;
+  fontUrl?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
@@ -32,36 +35,29 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   mockCampaign,
   customColors,
   jackpotColors,
+  logoUrl,
+  fontUrl,
   gameSize = 'large',
   gamePosition = 'center',
   previewDevice = 'desktop'
 }) => {
-  // Synchroniser les couleurs de la roue avec les couleurs personnalisées
-  const synchronizedCampaign = {
-    ...mockCampaign,
-    config: {
-      ...mockCampaign.config,
-      roulette: {
-        ...mockCampaign.config?.roulette,
-        borderColor: customColors.primary,
-        borderOutlineColor: customColors.accent || customColors.secondary,
-        segmentColor1: customColors.primary,
-        segmentColor2: customColors.secondary,
-        segments: mockCampaign.config?.roulette?.segments?.map((segment: any, index: number) => ({
-          ...segment,
-          color: index % 2 === 0 ? customColors.primary : customColors.secondary
-        })) || []
-      }
-    },
-    design: {
-      ...mockCampaign.design,
-      customColors: customColors
-    },
-    buttonConfig: {
-      ...mockCampaign.buttonConfig,
-      color: customColors.primary,
-      borderColor: customColors.primary
+  React.useEffect(() => {
+    if (fontUrl) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = fontUrl;
+      document.head.appendChild(link);
+      return () => {
+        document.head.removeChild(link);
+      };
     }
+  }, [fontUrl]);
+
+  // Appliquer la charte de marque à la configuration de la roue et du bouton
+  const synchronizedCampaign = applyBrandColorsToVisualStyle(mockCampaign, customColors as BrandColors);
+  synchronizedCampaign.design = {
+    ...synchronizedCampaign.design,
+    centerLogo: logoUrl || synchronizedCampaign.design?.centerLogo,
   };
 
   // Style universel pour tout centrer verticalement et horizontalement

--- a/src/components/QuickCampaign/Step2BasicSettings.tsx
+++ b/src/components/QuickCampaign/Step2BasicSettings.tsx
@@ -2,19 +2,26 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft, ArrowRight, Upload, Calendar, Target } from 'lucide-react';
 import { useQuickCampaignStore } from '../../stores/quickCampaignStore';
+import { analyzeBrandStyle } from '../../utils/BrandStyleAnalyzer';
 const Step2BasicSettings: React.FC = () => {
   const {
     campaignName,
     launchDate,
     marketingGoal,
     logoFile,
+    brandSiteUrl,
     setCampaignName,
     setLaunchDate,
     setMarketingGoal,
     setLogoFile,
+    setBrandSiteUrl,
+    setLogoUrl,
+    setFontUrl,
+    setCustomColors,
     setCurrentStep
   } = useQuickCampaignStore();
   const [dragActive, setDragActive] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
   const marketingGoals = [{
     id: 'leads',
     label: 'Générer des leads',
@@ -52,6 +59,26 @@ const Step2BasicSettings: React.FC = () => {
     setDragActive(false);
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
       setLogoFile(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleAnalyze = async () => {
+    if (!brandSiteUrl) return;
+    setIsAnalyzing(true);
+    try {
+      const styles = await analyzeBrandStyle(brandSiteUrl);
+      setCustomColors({
+        primary: styles.primaryColor,
+        secondary: styles.secondaryColor || styles.darkColor || '#E3F2FD',
+        accent: styles.lightColor || '#ffffff',
+      });
+      setLogoUrl(styles.logoUrl || null);
+      setFontUrl(styles.fontUrl || null);
+    } catch (err) {
+      console.error(err);
+      alert('Analyse impossible');
+    } finally {
+      setIsAnalyzing(false);
     }
   };
   const canProceed = campaignName.trim() && launchDate && marketingGoal;
@@ -97,6 +124,37 @@ const Step2BasicSettings: React.FC = () => {
                 Nom de la campagne
               </label>
               <input type="text" value={campaignName} onChange={e => setCampaignName(e.target.value)} placeholder="Ex: Jeu concours été 2024" className="w-full px-6 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#841b60] focus:outline-none transition-all text-lg bg-gray-50" />
+            </motion.div>
+
+            {/* Brand Website */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.25 }}
+            >
+              <label className="block text-lg font-medium text-gray-900 mb-4">
+                Site de la marque
+              </label>
+              <div className="flex space-x-4">
+                <input
+                  type="url"
+                  value={brandSiteUrl}
+                  onChange={(e) => setBrandSiteUrl(e.target.value)}
+                  placeholder="https://example.com"
+                  className="flex-1 px-6 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#841b60] focus:outline-none transition-all text-lg bg-gray-50"
+                />
+                <button
+                  type="button"
+                  onClick={handleAnalyze}
+                  className="px-4 py-3 rounded-2xl bg-[#841b60] text-white hover:bg-[#841b60]/90 transition-colors flex items-center justify-center"
+                >
+                  {isAnalyzing ? (
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                  ) : (
+                    <span>Analyser</span>
+                  )}
+                </button>
+              </div>
             </motion.div>
 
             {/* Launch Date */}

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -18,6 +18,8 @@ const Step3VisualStyle: React.FC = () => {
     launchDate,
     marketingGoal,
     logoFile,
+    logoUrl,
+    fontUrl,
     selectedTheme,
     backgroundImage,
     customColors,
@@ -232,7 +234,17 @@ const Step3VisualStyle: React.FC = () => {
               <div className="bg-gradient-to-br from-gray-50 to-gray-100 rounded-3xl shadow-inner border border-gray-200/50 max-w-2xl w-full flex items-center justify-center min-h-[400px] p-8">
                 {selectedGameType === 'jackpot' ? <JackpotPreview customColors={customColors} jackpotColors={jackpotColors} /> : <div className="flex flex-col items-center justify-center w-full h-full">
                     <div className="transform scale-90 origin-center">
-                      <GameRenderer gameType={selectedGameType || 'wheel'} mockCampaign={previewCampaign} customColors={customColors} jackpotColors={jackpotColors} gameSize="medium" gamePosition="center" previewDevice="desktop" />
+                      <GameRenderer
+                        gameType={selectedGameType || 'wheel'}
+                        mockCampaign={previewCampaign}
+                        customColors={customColors}
+                        jackpotColors={jackpotColors}
+                        logoUrl={logoUrl || undefined}
+                        fontUrl={fontUrl || undefined}
+                        gameSize="medium"
+                        gamePosition="center"
+                        previewDevice="desktop"
+                      />
                     </div>
                   </div>}
               </div>

--- a/src/stores/quickCampaignStore.ts
+++ b/src/stores/quickCampaignStore.ts
@@ -7,6 +7,9 @@ export interface QuickCampaignState {
   launchDate: string;
   marketingGoal: string;
   logoFile: File | null;
+  brandSiteUrl: string;
+  logoUrl: string | null;
+  fontUrl: string | null;
   selectedTheme: string;
   backgroundImage: File | null;
   segmentCount: number;
@@ -30,6 +33,9 @@ export interface QuickCampaignState {
   setLaunchDate: (date: string) => void;
   setMarketingGoal: (goal: string) => void;
   setLogoFile: (file: File | null) => void;
+  setBrandSiteUrl: (url: string) => void;
+  setLogoUrl: (url: string | null) => void;
+  setFontUrl: (url: string | null) => void;
   setSelectedTheme: (theme: string) => void;
   setBackgroundImage: (file: File | null) => void;
   setSegmentCount: (count: number) => void;
@@ -46,6 +52,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
   launchDate: '',
   marketingGoal: '',
   logoFile: null,
+  brandSiteUrl: '',
+  logoUrl: null,
+  fontUrl: null,
   selectedTheme: 'default',
   backgroundImage: null,
   segmentCount: 4,
@@ -71,6 +80,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
   setLaunchDate: (date) => set({ launchDate: date }),
   setMarketingGoal: (goal) => set({ marketingGoal: goal }),
   setLogoFile: (file) => set({ logoFile: file }),
+  setBrandSiteUrl: (url) => set({ brandSiteUrl: url }),
+  setLogoUrl: (url) => set({ logoUrl: url }),
+  setFontUrl: (url) => set({ fontUrl: url }),
   setSelectedTheme: (theme) => set({ selectedTheme: theme }),
   setBackgroundImage: (file) => set({ backgroundImage: file }),
   setSegmentCount: (count) => set({ segmentCount: count }),
@@ -86,11 +98,12 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
       type: state.selectedGameType || 'wheel',
       design: {
         customColors: state.customColors,
-        centerLogo: null,
+        centerLogo: state.logoUrl || null,
         mobileBackgroundImage: null
       },
       buttonConfig: {
         color: state.customColors.primary,
+        textColor: state.customColors.accent || '#ffffff',
         borderColor: state.customColors.primary,
         borderWidth: 2,
         borderRadius: 8,
@@ -149,7 +162,7 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
     baseConfig.mobileConfig = {
       roulette: baseConfig.config.roulette,
       buttonColor: state.customColors.primary,
-      buttonTextColor: '#ffffff',
+      buttonTextColor: state.customColors.accent || '#ffffff',
       buttonPlacement: 'bottom',
       gamePosition: 'center'
     };
@@ -164,6 +177,9 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
     launchDate: '',
     marketingGoal: '',
     logoFile: null,
+    brandSiteUrl: '',
+    logoUrl: null,
+    fontUrl: null,
     selectedTheme: 'default',
     backgroundImage: null,
     segmentCount: 4,

--- a/src/utils/BrandStyleAnalyzer.ts
+++ b/src/utils/BrandStyleAnalyzer.ts
@@ -1,0 +1,93 @@
+export interface BrandStyle {
+  primaryColor: string;
+  logoUrl?: string;
+  fontUrl?: string;
+  faviconUrl?: string;
+  secondaryColor?: string;
+  lightColor?: string;
+  darkColor?: string;
+}
+
+export async function analyzeBrandStyle(siteUrl: string): Promise<BrandStyle> {
+  const apiUrl = `https://api.microlink.io/?url=${encodeURIComponent(siteUrl)}&palette=true&meta=true&screenshot=true`;
+  const res = await fetch(apiUrl);
+  if (!res.ok) {
+    throw new Error('Microlink request failed');
+  }
+  const json = await res.json();
+  const data = json.data || {};
+  const screenshot = data.screenshot || {};
+  const palette = screenshot.palette || [];
+  const primaryColor =
+    data?.palette?.vibrant?.background ||
+    data?.palette?.lightVibrant?.background ||
+    data?.palette?.darkVibrant?.background ||
+    screenshot.background_color ||
+    palette[0] ||
+    '#841b60';
+
+  const secondaryColor =
+    data?.palette?.darkVibrant?.background ||
+    palette[1] ||
+    screenshot.color;
+  const lightColor =
+    data?.palette?.lightVibrant?.background ||
+    palette[3] ||
+    screenshot.alternative_color;
+  const darkColor =
+    data?.palette?.darkVibrant?.background ||
+    palette[0] ||
+    screenshot.background_color;
+
+  return {
+    primaryColor,
+    logoUrl: data.logo?.url,
+    fontUrl: data.font?.url,
+    faviconUrl: data.favicon?.url,
+    secondaryColor,
+    lightColor,
+    darkColor,
+  };
+}
+
+export interface BrandColors {
+  primary: string;
+  secondary: string;
+  accent?: string;
+}
+
+// Central helper to apply a brand color scheme to a wheel configuration
+export function applyBrandColorsToVisualStyle(campaign: any, colors: BrandColors) {
+  const updatedSegments = (campaign?.config?.roulette?.segments || []).map(
+    (segment: any) => ({
+      ...segment,
+      color: segment.color || colors.primary
+    })
+  );
+
+  return {
+    ...campaign,
+    config: {
+      ...campaign.config,
+      roulette: {
+        ...(campaign.config?.roulette || {}),
+        borderColor: colors.secondary || colors.primary,
+        borderOutlineColor: colors.accent || colors.primary,
+        segmentColor1: colors.primary,
+        segmentColor2: colors.primary,
+        segments: updatedSegments
+      }
+    },
+    design: {
+      ...(campaign.design || {}),
+      customColors: colors
+    },
+    buttonConfig: {
+      ...(campaign.buttonConfig || {}),
+      color: colors.secondary || colors.primary,
+      textColor: colors.accent || '#ffffff',
+      borderColor: colors.secondary || colors.primary
+    }
+  };
+}
+


### PR DESCRIPTION
## Summary
- refine Microlink color extraction using screenshot data
- map extracted colors to campaign custom colors
- style wheel segments and button using extracted brand colors

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849a4567d98832a9fba5b4ce8d06388