### PR TITLE
Fix preview background and centering

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import GameRenderer from './GameRenderer';
 import { GameSize } from '../configurators/GameSizeSelector';
+import useCenteredStyles from '../../hooks/useCenteredStyles';
+import { getCampaignBackgroundImage } from '../../utils/background';
 
 interface GameCanvasPreviewProps {
   campaign: any;
@@ -19,35 +21,38 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   className = '',
   previewDevice = 'desktop'
 }) => {
+  const { containerStyle, wrapperStyle } = useCenteredStyles();
+
+  // Déterminer l'image de fond à appliquer
+  const resolvedBackground =
+    gameBackgroundImage || getCampaignBackgroundImage(campaign, previewDevice);
+
   // Style du conteneur principal avec image de fond
-  const containerStyle: React.CSSProperties = {
-    width: '100%',
+  const containerStyles: React.CSSProperties = {
+    ...containerStyle,
     height: '400px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
     position: 'relative',
     overflow: 'hidden'
   };
 
   // Appliquer l'image de fond si elle existe
-  if (gameBackgroundImage) {
-    containerStyle.backgroundImage = `url(${gameBackgroundImage})`;
-    containerStyle.backgroundSize = 'cover';
-    containerStyle.backgroundPosition = 'center';
-    containerStyle.backgroundRepeat = 'no-repeat';
+  if (resolvedBackground) {
+    containerStyles.backgroundImage = `url(${resolvedBackground})`;
+    containerStyles.backgroundSize = 'cover';
+    containerStyles.backgroundPosition = 'center';
+    containerStyles.backgroundRepeat = 'no-repeat';
   }
 
   return (
     <div className={`bg-white rounded-lg border-2 border-gray-200 overflow-hidden ${className}`}>
-      <div style={containerStyle}>
+      <div style={containerStyles}>
         {/* Overlay pour améliorer la lisibilité si image de fond */}
-        {gameBackgroundImage && (
+        {resolvedBackground && (
           <div className="absolute inset-0 bg-black/10" />
         )}
-        
+
         {/* Conteneur du jeu - toujours centré par défaut */}
-        <div className="relative z-10 flex items-center justify-center w-full h-full">
+        <div className="relative z-10" style={wrapperStyle}>
           <GameRenderer
             campaign={campaign}
             gameSize={gameSize}
@@ -55,7 +60,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
             previewDevice={previewDevice}
             buttonLabel={campaign.buttonConfig?.text || 'Jouer'}
             buttonColor={campaign.buttonConfig?.color || '#841b60'}
-            gameBackgroundImage={gameBackgroundImage}
+            gameBackgroundImage={resolvedBackground}
           />
         </div>
       </div>

--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -9,6 +9,8 @@ import ScratchPreview from '../GameTypes/ScratchPreview';
 import DicePreview from '../GameTypes/DicePreview';
 import FormPreview from '../GameTypes/FormPreview';
 import { GameSize } from '../configurators/GameSizeSelector';
+import { useGamePositionCalculator } from './GamePositionCalculator';
+import useCenteredStyles from '../../hooks/useCenteredStyles';
 
 interface GameRendererProps {
   campaign: any;
@@ -28,35 +30,19 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   buttonColor,
   gameBackgroundImage
 }) => {
-  // Style de conteneur centré universel qui fonctionne dans tous les contextes
-  const centeredContainerStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    height: '100%',
-    minHeight: '400px',
-    position: 'relative',
-    padding: '20px',
-    boxSizing: 'border-box'
-  };
-
-  // Wrapper du jeu avec style cohérent
-  const gameWrapperStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'column',
-    gap: '20px',
-    maxWidth: '100%',
-    maxHeight: '100%'
-  };
+  const { containerStyle, wrapperStyle } = useCenteredStyles();
+  const gamePosition = campaign.gamePosition || 'center';
+  const { getPositionStyles } = useGamePositionCalculator({
+    gameSize,
+    gamePosition,
+    shouldCropWheel: false
+  });
 
   switch (campaign.type) {
     case 'jackpot':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <Jackpot
               isPreview={true}
               instantWinConfig={{
@@ -82,8 +68,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'quiz':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <Quiz config={campaign.gameConfig?.quiz || {}} onConfigChange={() => {}} />
           </div>
         </div>
@@ -91,8 +77,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'wheel':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <WheelPreview
               campaign={campaign}
               config={{
@@ -103,7 +89,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
               }}
               onFinish={() => {}}
               gameSize={gameSize}
-              gamePosition="center" // Toujours centré par défaut
+              gamePosition={gamePosition}
               previewDevice={previewDevice}
               key={`${gameSize}-center-${previewDevice}-${JSON.stringify(campaign.gameConfig?.wheel)}`}
             />
@@ -113,8 +99,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'scratch':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <ScratchPreview
               config={campaign.gameConfig?.scratch || {}}
               buttonLabel={buttonLabel}
@@ -128,8 +114,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'memory':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <MemoryPreview config={campaign.gameConfig?.memory || {}} />
           </div>
         </div>
@@ -137,8 +123,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'puzzle':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <PuzzlePreview config={campaign.gameConfig?.puzzle || {}} />
           </div>
         </div>
@@ -146,8 +132,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'dice':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <DicePreview config={campaign.gameConfig?.dice || {}} />
           </div>
         </div>
@@ -155,8 +141,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     case 'form':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <FormPreview
               campaign={campaign}
               gameSize={gameSize}
@@ -167,8 +153,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
     default:
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <div className="text-center text-gray-500 flex items-center justify-center h-full">
               <p className="text-sm">Type de jeu non pris en charge</p>
             </div>

--- a/src/components/CampaignEditor/PreviewModal.tsx
+++ b/src/components/CampaignEditor/PreviewModal.tsx
@@ -4,6 +4,7 @@ import { X, Monitor, Tablet, Smartphone } from 'lucide-react';
 import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
 import FunnelStandard from '../funnels/FunnelStandard';
 import CampaignPreview from './CampaignPreview';
+import { getCampaignBackgroundImage } from '../../utils/background';
 
 interface PreviewModalProps {
   isOpen: boolean;
@@ -45,8 +46,7 @@ const PreviewModal: React.FC<PreviewModalProps> = ({ isOpen, onClose, campaign }
   };
 
   // Récupérer l'image de fond du jeu
-  const gameBackgroundImage = campaign.gameConfig?.[campaign.type]?.backgroundImage || 
-                              campaign.design?.backgroundImage;
+  const gameBackgroundImage = getCampaignBackgroundImage(campaign, selectedDevice);
 
   const getBackgroundStyle = () => {
     const style: any = {

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -5,6 +5,8 @@ import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import FormPreview from '../../GameTypes/FormPreview';
 import { applyBrandStyleToWheel, BrandColors } from '../../../utils/BrandStyleAnalyzer';
+import { useGamePositionCalculator } from '../../CampaignEditor/GamePositionCalculator';
+import useCenteredStyles from '../../../hooks/useCenteredStyles';
 
 interface GameRendererProps {
   gameType: string;
@@ -61,32 +63,18 @@ const GameRenderer: React.FC<GameRendererProps> = ({
     centerLogo: logoUrl || synchronizedCampaign.design?.centerLogo,
   };
 
-  // Style universel pour centrer la mécanique
-  const centeredContainerStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    height: '100%',
-    minHeight: '400px',
-    position: 'relative',
-    padding: '20px',
-    boxSizing: 'border-box'
-  };
-
-  const gameWrapperStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'column',
-    gap: '20px'
-  };
+  const { containerStyle, wrapperStyle } = useCenteredStyles();
+  const { getPositionStyles } = useGamePositionCalculator({
+    gameSize,
+    gamePosition,
+    shouldCropWheel: false
+  });
 
   switch (gameType) {
     case 'wheel':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <WheelPreview
               campaign={synchronizedCampaign}
               config={mockCampaign.gameConfig?.wheel || {
@@ -104,8 +92,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       );
     case 'jackpot':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <Jackpot
               isPreview={true}
               instantWinConfig={mockCampaign.gameConfig?.jackpot?.instantWin || {
@@ -130,8 +118,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       );
     case 'scratch':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <ScratchPreview
               config={mockCampaign.gameConfig?.scratch || {}}
               autoStart
@@ -141,8 +129,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       );
     case 'dice':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <DicePreview
               config={mockCampaign.gameConfig?.dice || {}}
             />
@@ -151,8 +139,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       );
     case 'form':
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <FormPreview
               campaign={synchronizedCampaign}
               gameSize={gameSize}
@@ -162,8 +150,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       );
     default:
       return (
-        <div style={centeredContainerStyle}>
-          <div style={gameWrapperStyle}>
+        <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
+          <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
             <div className="text-center text-gray-500">
               <p>Type de jeu non supporté: {gameType}</p>
             </div>

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -7,6 +7,9 @@ import { Jackpot } from '../../GameTypes';
 import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import { GAME_SIZES, GameSize } from '../../configurators/GameSizeSelector';
+import { useGamePositionCalculator } from '../../CampaignEditor/GamePositionCalculator';
+import useCenteredStyles from '../../../hooks/useCenteredStyles';
+import { getCampaignBackgroundImage } from '../../../utils/background';
 
 interface GameRendererProps {
   campaign: any;
@@ -29,7 +32,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   onGameStart,
   onGameButtonClick
 }) => {
-  const gameBackgroundImage = campaign.gameConfig?.[campaign.type]?.backgroundImage;
+  const gameBackgroundImage = getCampaignBackgroundImage(campaign, previewMode);
   const buttonLabel = campaign.gameConfig?.[campaign.type]?.buttonLabel || campaign.buttonConfig?.text;
   const buttonColor = campaign.buttonConfig?.color || campaign.gameConfig?.[campaign.type]?.buttonColor || '#841b60';
   const contrastBg = mobileConfig?.contrastBackground || campaign.screens?.[2]?.contrastBackground;
@@ -42,31 +45,12 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   // Détecter si on est dans une modal (pour ajuster l'affichage)
   const isModal = previewMode !== 'desktop' || window.location.pathname.includes('preview');
 
-  // Universal centering container that works in all contexts
-  const getGameContainerStyle = (): React.CSSProperties => {
-    return {
-      width: '100%',
-      height: '100%',
-      minHeight: '400px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      position: 'relative',
-      padding: '20px',
-      boxSizing: 'border-box'
-    };
-  };
-
-  // Game wrapper with consistent styling
-  const gameWrapperStyle: React.CSSProperties = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'column',
-    gap: '16px',
-    maxWidth: '100%',
-    maxHeight: '100%'
-  };
+  const { containerStyle, wrapperStyle } = useCenteredStyles();
+  const { getPositionStyles } = useGamePositionCalculator({
+    gameSize,
+    gamePosition,
+    shouldCropWheel: false
+  });
 
   const handleGameComplete = (result: 'win' | 'lose') => {
     onGameFinish(result);
@@ -142,8 +126,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   };
 
   return (
-    <div style={getGameContainerStyle()} className="rounded-lg overflow-visible relative">
-      <div style={gameWrapperStyle}>
+    <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }} className="rounded-lg overflow-visible relative">
+      <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
         <ContrastBackground
           enabled={contrastBg?.enabled && contrastBg?.applyToGame}
           config={contrastBg}

--- a/src/hooks/useCenteredStyles.ts
+++ b/src/hooks/useCenteredStyles.ts
@@ -1,0 +1,36 @@
+import { CSSProperties, useMemo } from 'react';
+
+export interface CenteredStyles {
+  containerStyle: CSSProperties;
+  wrapperStyle: CSSProperties;
+}
+
+export const useCenteredStyles = (): CenteredStyles => {
+  const containerStyle = useMemo<CSSProperties>(
+    () => ({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '100%',
+      height: '100%'
+    }),
+    []
+  );
+
+  const wrapperStyle = useMemo<CSSProperties>(
+    () => ({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+      gap: '20px',
+      width: '100%',
+      height: '100%'
+    }),
+    []
+  );
+
+  return { containerStyle, wrapperStyle };
+};
+
+export default useCenteredStyles;

--- a/src/utils/background.ts
+++ b/src/utils/background.ts
@@ -1,0 +1,15 @@
+export type PreviewDevice = 'desktop' | 'tablet' | 'mobile';
+
+export const getCampaignBackgroundImage = (
+  campaign: any,
+  device: PreviewDevice = 'desktop'
+): string | undefined => {
+  if (!campaign) return undefined;
+  const design = campaign.design || {};
+
+  if (device === 'mobile') {
+    return design.mobileBackgroundImage || design.backgroundImage;
+  }
+
+  return design.backgroundImage;
+};


### PR DESCRIPTION
## Summary
- compute centered container styles via reusable hook
- read desktop/mobile background images from design and apply in all previews
- ensure game previews respect the chosen game position

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c29fd038832a9df4a98301aa867f