### PR TITLE
Add local logo color extraction

### DIFF
--- a/src/components/LogoUploader.tsx
+++ b/src/components/LogoUploader.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { Upload } from 'lucide-react';
+import { useQuickCampaignStore } from '../stores/quickCampaignStore';
+import { generateBrandThemeFromFile } from '../utils/BrandStyleAnalyzer';
+
+interface LogoUploaderProps {
+  className?: string;
+}
+
+const LogoUploader: React.FC<LogoUploaderProps> = ({ className }) => {
+  const {
+    setLogoFile,
+    setLogoUrl,
+    setCustomColors,
+    setJackpotColors,
+    jackpotColors,
+    selectedGameType,
+    customColors
+  } = useQuickCampaignStore();
+
+  const [dragActive, setDragActive] = useState(false);
+  const [palette, setPalette] = useState<string[]>([]);
+
+  const applyThemeFromFile = async (file: File) => {
+    setLogoFile(file);
+    const url = URL.createObjectURL(file);
+    setLogoUrl(url);
+    try {
+      const theme = await generateBrandThemeFromFile(file);
+      setPalette([
+        theme.customColors.primary,
+        theme.customColors.secondary,
+        theme.customColors.accent
+      ]);
+      setCustomColors({
+        primary: theme.customColors.primary,
+        secondary: theme.customColors.secondary,
+        accent: theme.customColors.accent,
+        textColor: theme.customColors.text
+      });
+      if (selectedGameType === 'jackpot') {
+        setJackpotColors({
+          ...jackpotColors,
+          containerBackgroundColor: theme.customColors.accent + '30',
+          backgroundColor: theme.customColors.accent + '30',
+          borderColor: theme.customColors.primary,
+          slotBorderColor: theme.customColors.secondary,
+          slotBackgroundColor: '#ffffff'
+        });
+      }
+    } catch (err) {
+      console.error('Failed to extract palette', err);
+    }
+  };
+
+  const handleUpload = (files: FileList | null) => {
+    if (files && files[0]) {
+      applyThemeFromFile(files[0]);
+    }
+  };
+
+  const handleDrag = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === 'dragenter' || e.type === 'dragover') setDragActive(true);
+    else if (e.type === 'dragleave') setDragActive(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      applyThemeFromFile(e.dataTransfer.files[0]);
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className={`relative border-2 border-dashed rounded-2xl p-8 text-center transition-all bg-gray-50 ${dragActive ? 'border-[#841b60] bg-[#841b60]/5' : 'border-gray-300'} ${className || ''}`}
+        onDragEnter={handleDrag}
+        onDragLeave={handleDrag}
+        onDragOver={handleDrag}
+        onDrop={handleDrop}
+      >
+        <Upload className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+        <p className="text-gray-600 mb-2">
+          <label className="text-[#841b60] cursor-pointer hover:text-[#841b60]/80 transition-colors">
+            Cliquez pour télécharger
+            <input type="file" accept="image/*" onChange={e => handleUpload(e.target.files)} className="hidden" />
+          </label>{' '}
+          ou glissez-déposez votre logo
+        </p>
+        <p className="text-gray-400 text-sm">PNG, JPG, JPEG ou SVG jusqu'à 10MB</p>
+      </div>
+      {palette.length > 0 && (
+        <div className="flex items-center justify-center space-x-2 mt-4">
+          {palette.map(color => (
+            <div key={color} className="w-6 h-6 rounded-full border" style={{ backgroundColor: color }} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LogoUploader;

--- a/src/components/QuickCampaign/Preview/GameRenderer.tsx
+++ b/src/components/QuickCampaign/Preview/GameRenderer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useGamePositionCalculator } from '../../CampaignEditor/GamePositionCalculator';
 import useCenteredStyles from '../../../hooks/useCenteredStyles';
-import { useBrandColorExtraction } from './hooks/useBrandColorExtraction';
 import { synchronizeCampaignWithColors } from './utils/campaignSynchronizer';
 import GameSwitcher from './components/GameSwitcher';
 
@@ -24,7 +23,6 @@ interface GameRendererProps {
   };
   logoUrl?: string;
   fontUrl?: string;
-  siteUrl?: string;
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
@@ -37,13 +35,12 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   jackpotColors,
   logoUrl,
   fontUrl,
-  siteUrl,
   gameSize = 'large',
   gamePosition = 'center',
   previewDevice = 'desktop'
 }) => {
-  // Extraction des couleurs de marque
-  const { finalColors } = useBrandColorExtraction(customColors, siteUrl);
+  // Couleurs directement issues du logo
+  const finalColors = customColors;
 
   // Chargement dynamique de la police
   React.useEffect(() => {

--- a/src/components/QuickCampaign/Step2BasicSettings.tsx
+++ b/src/components/QuickCampaign/Step2BasicSettings.tsx
@@ -1,30 +1,19 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
-import { ArrowLeft, ArrowRight, Upload, Calendar, Target } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Calendar, Target } from 'lucide-react';
 import { useQuickCampaignStore } from '../../stores/quickCampaignStore';
-import { generateBrandThemeFromUrl } from '../../utils/BrandStyleAnalyzer';
+import LogoUploader from '../LogoUploader';
 
 const Step2BasicSettings: React.FC = () => {
   const {
     campaignName,
     launchDate,
     marketingGoal,
-    logoFile,
-    brandSiteUrl,
     setCampaignName,
     setLaunchDate,
     setMarketingGoal,
-    setLogoFile,
-    setBrandSiteUrl,
-    setLogoUrl,
-    setFontUrl,
-    setCustomColors,
-    setJackpotColors,
     setCurrentStep
   } = useQuickCampaignStore();
-
-  const [dragActive, setDragActive] = useState(false);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
 
   const marketingGoals = [
     { id: 'leads', label: 'Générer des leads', description: 'Collecter des contacts qualifiés' },
@@ -33,57 +22,7 @@ const Step2BasicSettings: React.FC = () => {
     { id: 'sales', label: 'Augmenter les ventes', description: 'Convertir plus de prospects' }
   ];
 
-  const handleFileUpload = (files: FileList | null) => {
-    if (files && files[0]) setLogoFile(files[0]);
-  };
-
-  const handleDrag = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (e.type === 'dragenter' || e.type === 'dragover') setDragActive(true);
-    else if (e.type === 'dragleave') setDragActive(false);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragActive(false);
-    if (e.dataTransfer.files && e.dataTransfer.files[0]) setLogoFile(e.dataTransfer.files[0]);
-  };
-
-  const handleAnalyze = async () => {
-    if (!brandSiteUrl) return;
-    setIsAnalyzing(true);
-    try {
-      const theme = await generateBrandThemeFromUrl(brandSiteUrl);
-
-      setCustomColors({
-        primary: theme.customColors.primary,
-        secondary: theme.customColors.secondary,
-        accent: theme.customColors.accent,
-        textColor: theme.customColors.text
-      });
-
-      setJackpotColors({
-        containerBackgroundColor: theme.customColors.accent + '30',
-        backgroundColor: theme.customColors.accent + '30',
-        borderColor: theme.customColors.primary,
-        borderWidth: 3,
-        slotBorderColor: theme.customColors.secondary,
-        slotBorderWidth: 2,
-        slotBackgroundColor: '#ffffff'
-      });
-
-      setLogoUrl(theme.logoUrl || null);
-      setFontUrl(null);
-
-    } catch (err) {
-      console.error('❌ Erreur lors de l\'analyse:', err);
-      alert('Impossible d\'analyser ce site. Vérifiez l\'URL ou réessayez plus tard.');
-    } finally {
-      setIsAnalyzing(false);
-    }
-  };
+  // Les couleurs seront extraites automatiquement via le composant LogoUploader
 
   const canProceed = campaignName.trim() && launchDate && marketingGoal;
 
@@ -114,42 +53,6 @@ const Step2BasicSettings: React.FC = () => {
               />
             </motion.div>
 
-            {/* Brand Website */}
-            <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.25 }}>
-              <label className="block text-lg font-medium text-gray-900 mb-4">
-                Site de la marque
-                <span className="text-sm font-normal text-gray-500 ml-2">
-                  (analyse intelligente de la charte graphique complète)
-                </span>
-              </label>
-              <div className="flex space-x-4">
-                <input
-                  type="url"
-                  value={brandSiteUrl}
-                  onChange={e => setBrandSiteUrl(e.target.value)}
-                  placeholder="https://www.sfr.fr"
-                  className="flex-1 px-6 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#841b60] focus:outline-none transition-all text-lg bg-gray-50"
-                />
-                <button
-                  type="button"
-                  onClick={handleAnalyze}
-                  disabled={!brandSiteUrl || isAnalyzing}
-                  className="px-6 py-4 rounded-2xl bg-[#841b60] text-white hover:bg-[#841b60]/90 transition-colors flex items-center justify-center font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isAnalyzing ? (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                      <span>Analyse...</span>
-                    </div>
-                  ) : (
-                    <span>🎨 Analyser</span>
-                  )}
-                </button>
-              </div>
-              <p className="text-sm text-gray-600 mt-2">
-                💡 L'analyse extraira automatiquement les couleurs dominantes, le logo et la police de votre site pour une personnalisation sans effort.
-              </p>
-            </motion.div>
 
             {/* Launch Date */}
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.3 }}>
@@ -193,38 +96,7 @@ const Step2BasicSettings: React.FC = () => {
               <label className="block text-lg font-medium text-gray-900 mb-4">
                 Logo <span className="text-gray-500 font-normal">(optionnel)</span>
               </label>
-              <div
-                className={`
-                  relative border-2 border-dashed rounded-2xl p-8 text-center transition-all bg-gray-50
-                  ${dragActive ? 'border-[#841b60] bg-[#841b60]/5' : 'border-gray-300'}
-                  ${logoFile ? 'border-green-400 bg-green-50' : ''}
-                `}
-                onDragEnter={handleDrag}
-                onDragLeave={handleDrag}
-                onDragOver={handleDrag}
-                onDrop={handleDrop}
-              >
-                <Upload className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                {logoFile ? (
-                  <div>
-                    <p className="text-gray-900 font-medium mb-2">{logoFile.name}</p>
-                    <button onClick={() => setLogoFile(null)} className="text-red-500 hover:text-red-600 transition-colors">
-                      Supprimer
-                    </button>
-                  </div>
-                ) : (
-                  <>
-                    <p className="text-gray-600 mb-2">
-                      <label className="text-[#841b60] cursor-pointer hover:text-[#841b60]/80 transition-colors">
-                        Cliquez pour télécharger
-                        <input type="file" accept="image/*" onChange={e => handleFileUpload(e.target.files)} className="hidden" />
-                      </label>
-                      {' '}ou glissez-déposez votre logo
-                    </p>
-                    <p className="text-gray-400 text-sm">PNG, JPG jusqu'à 10MB</p>
-                  </>
-                )}
-              </div>
+              <LogoUploader />
             </motion.div>
           </div>
 

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { ArrowLeft, Upload, Eye, Settings, CheckCircle, AlertCircle } from 'lucide-react';
+import React, { useState, useRef } from 'react';
+import { ArrowLeft, Upload, Eye, Settings, CheckCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useQuickCampaignStore } from '../../stores/quickCampaignStore';
 import { useCampaigns } from '../../hooks/useCampaigns';
@@ -21,7 +21,6 @@ const Step3VisualStyle: React.FC = () => {
     logoFile,
     logoUrl,
     fontUrl,
-    brandSiteUrl,
     selectedTheme,
     backgroundImage,
     customColors,
@@ -37,30 +36,10 @@ const Step3VisualStyle: React.FC = () => {
   const [isCreating, setIsCreating] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [creationSuccess, setCreationSuccess] = useState(false);
-  const [extractionStatus, setExtractionStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [extractionMessage, setExtractionMessage] = useState<string>('');
   
   const previewCampaign = generatePreviewCampaign();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Surveillance de l'extraction automatique des couleurs
-  useEffect(() => {
-    if (brandSiteUrl && brandSiteUrl.trim() !== '') {
-      setExtractionStatus('loading');
-      setExtractionMessage('Analyse de la marque et extraction des couleurs du logo...');
-      
-      // Simulation du processus d'extraction (sera géré par le hook)
-      const timer = setTimeout(() => {
-        setExtractionStatus('success');
-        setExtractionMessage('Couleurs de marque extraites avec succès !');
-      }, 3000);
-      
-      return () => clearTimeout(timer);
-    } else {
-      setExtractionStatus('idle');
-      setExtractionMessage('');
-    }
-  }, [brandSiteUrl]);
 
   const handleFileUpload = (files: FileList | null) => {
     if (files && files[0]) {
@@ -257,40 +236,6 @@ const Step3VisualStyle: React.FC = () => {
           </div>
 
           <div className="space-y-16">
-            {/* Statut de l'extraction des couleurs de marque */}
-            {brandSiteUrl && (
-              <div className="mb-8">
-                {extractionStatus === 'loading' && (
-                  <div className="flex items-center space-x-3 text-blue-600 bg-blue-50 p-4 rounded-lg">
-                    <div className="w-5 h-5 border-2 border-blue-600/30 border-t-blue-600 rounded-full animate-spin"></div>
-                    <div>
-                      <p className="font-medium">Extraction automatique des couleurs de marque</p>
-                      <p className="text-sm text-blue-500 mt-1">{extractionMessage}</p>
-                    </div>
-                  </div>
-                )}
-                
-                {extractionStatus === 'success' && (
-                  <div className="flex items-center space-x-3 text-green-600 bg-green-50 p-4 rounded-lg">
-                    <CheckCircle className="w-5 h-5" />
-                    <div>
-                      <p className="font-medium">🎨 Couleurs de marque appliquées automatiquement</p>
-                      <p className="text-sm text-green-500 mt-1">Les couleurs ont été extraites du logo et appliquées à votre campagne</p>
-                    </div>
-                  </div>
-                )}
-                
-                {extractionStatus === 'error' && (
-                  <div className="flex items-start space-x-3 text-amber-600 bg-amber-50 p-4 rounded-lg">
-                    <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <p className="font-medium">Extraction partielle des couleurs</p>
-                      <p className="text-sm text-amber-500 mt-1">Certaines couleurs ont pu être extraites. Vous pouvez les ajuster manuellement si nécessaire.</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
 
             {/* Aperçu dynamique du jeu - Design unifié pour toutes les mécaniques */}
             <div className="flex justify-center">
@@ -310,7 +255,6 @@ const Step3VisualStyle: React.FC = () => {
                         jackpotColors={jackpotColors}
                         logoUrl={logoUrl || undefined}
                         fontUrl={fontUrl || undefined}
-                        siteUrl={brandSiteUrl || undefined}
                         gameSize="medium"
                         gamePosition="center"
                         previewDevice="desktop"

--- a/src/utils/BrandStyleAnalyzer.ts
+++ b/src/utils/BrandStyleAnalyzer.ts
@@ -30,7 +30,9 @@ import ColorThief from 'colorthief';
 
 // --- APPEL API Brandfetch AVEC SÉCURITÉ CLÉ ---
 async function fetchBrandfetchData(domain: string): Promise<any> {
-  const apiKey = import.meta.env.VITE_BRANDFETCH_KEY;
+  const apiKey =
+    (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_BRANDFETCH_KEY) ||
+    process.env.VITE_BRANDFETCH_KEY;
   if (!apiKey) {
     console.warn(
       '[BrandStyleAnalyzer] VITE_BRANDFETCH_KEY is undefined. Skipping Brandfetch request.'
@@ -114,6 +116,37 @@ export async function generateBrandThemeFromUrl(url: string): Promise<BrandTheme
       }
     };
   }
+}
+
+// Génération d'un thème de marque à partir d'un fichier logo local
+export async function generateBrandThemeFromFile(file: File): Promise<BrandTheme> {
+  const logoUrl = URL.createObjectURL(file);
+  try {
+    const logoColors = await extractColorsFromLogo(logoUrl);
+    if (logoColors.length >= 2) {
+      const palette = generateAdvancedPaletteFromColors(logoColors);
+      return {
+        customColors: {
+          primary: palette.primaryColor,
+          secondary: palette.secondaryColor,
+          accent: palette.accentColor,
+          text: palette.textColor
+        },
+        logoUrl
+      };
+    }
+  } catch (error) {
+    console.warn('⚠️ Échec extraction logo local:', error);
+  }
+  return {
+    customColors: {
+      primary: '#841b60',
+      secondary: '#dc2626',
+      accent: '#10b981',
+      text: '#ffffff'
+    },
+    logoUrl
+  };
 }
 
 // Récupération des données Brandfetch


### PR DESCRIPTION
## Summary
- create `LogoUploader` component to pick a logo file and extract colors with ColorThief
- generate brand theme from a local logo in `BrandStyleAnalyzer`
- simplify basic settings by removing Brandfetch logic
- drop site URL based color extraction from game preview
- clean visual style step
- handle missing Brandfetch key in tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a0e3a937c832a8840ebf7d5f92485