### PR TITLE
Add tests and update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ before building the project.
 
 ## Testing
 
-To run the unit tests you must first install the development dependencies so the
-`tsx` runner is available. Then execute the test script:
+Install dependencies and execute the test suite:
 
 ```bash
-npm install
+npm ci
 npm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "build:dev": "vite build --mode development",
-    "test": "npx tsx test/BrandStyleAnalyzer.test.ts"
+    "test": "npx tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/test/BrandStyleAnalyzer.utils.test.ts
+++ b/test/BrandStyleAnalyzer.utils.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getAccessibleTextColor, generateAdvancedPaletteFromColors, extractCompletePaletteFromBrandfetch } from '../src/utils/BrandStyleAnalyzer';
+
+test('getAccessibleTextColor returns contrasting color', () => {
+  assert.equal(getAccessibleTextColor('#ffffff'), '#000000');
+  assert.equal(getAccessibleTextColor('#000000'), '#ffffff');
+});
+
+test('generateAdvancedPaletteFromColors picks first color as primary', () => {
+  const palette = generateAdvancedPaletteFromColors(['#111111', '#eeeeee']);
+  assert.equal(palette.primaryColor, '#111111');
+});
+
+test('extractCompletePaletteFromBrandfetch transforms palette', () => {
+  const res = extractCompletePaletteFromBrandfetch([{ hex: '#ff0000' }, '#00ff00']);
+  assert.equal(res.primaryColor, '#ff0000');
+  assert.equal(res.secondaryColor, '#00ff00');
+});

--- a/test/background.test.ts
+++ b/test/background.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCampaignBackgroundImage } from '../src/utils/background';
+
+test('getCampaignBackgroundImage returns desktop background', () => {
+  const campaign = { design: { backgroundImage: 'desktop.jpg', mobileBackgroundImage: 'mobile.jpg' } };
+  assert.equal(getCampaignBackgroundImage(campaign), 'desktop.jpg');
+});
+
+test('getCampaignBackgroundImage returns mobile background when device is mobile', () => {
+  const campaign = { design: { backgroundImage: 'desktop.jpg', mobileBackgroundImage: 'mobile.jpg' } };
+  assert.equal(getCampaignBackgroundImage(campaign, 'mobile'), 'mobile.jpg');
+});

--- a/test/newsletterStore.test.ts
+++ b/test/newsletterStore.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { useNewsletterStore } from '../src/stores/newsletterStore';
+
+test('newsletterStore add and remove module', () => {
+  useNewsletterStore.setState({ modules: [] });
+  const module = { id: '1', type: 'text', content: 'hello', settings: {} };
+  useNewsletterStore.getState().addModule(module);
+  assert.equal(useNewsletterStore.getState().modules.length, 1);
+  useNewsletterStore.getState().removeModule('1');
+  assert.equal(useNewsletterStore.getState().modules.length, 0);
+});
+
+test('newsletterStore update module', () => {
+  useNewsletterStore.setState({ modules: [] });
+  const module = { id: '1', type: 'text', content: 'hello', settings: {} };
+  useNewsletterStore.getState().addModule(module);
+  useNewsletterStore.getState().updateModule('1', { content: 'world' });
+  assert.equal(useNewsletterStore.getState().modules[0].content, 'world');
+});
+

--- a/test/quickCampaignStore.test.ts
+++ b/test/quickCampaignStore.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { useQuickCampaignStore } from '../src/stores/quickCampaignStore';
+
+test('quickCampaignStore setCampaignName and reset', () => {
+  useQuickCampaignStore.setState({ campaignName: 'Initial' });
+  useQuickCampaignStore.getState().setCampaignName('Changed');
+  assert.equal(useQuickCampaignStore.getState().campaignName, 'Changed');
+  useQuickCampaignStore.getState().reset();
+  assert.equal(useQuickCampaignStore.getState().campaignName, 'Ma Nouvelle Campagne');
+});
+
+test('generatePreviewCampaign reflects segment count', () => {
+  useQuickCampaignStore.getState().setSelectedGameType('wheel');
+  useQuickCampaignStore.getState().setSegmentCount(3);
+  const preview = useQuickCampaignStore.getState().generatePreviewCampaign();
+  assert.equal(preview.config.roulette.segments.length, 3);
+});

--- a/test/wheelConfig.test.ts
+++ b/test/wheelConfig.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getWheelSegments, getWheelDimensions } from '../src/utils/wheelConfig';
+
+test('getWheelSegments fills missing colors', () => {
+  const campaign = {
+    config: {
+      roulette: {
+        segments: [{ label: 'A' }, { label: 'B' }],
+        segmentColor1: '#111111',
+        segmentColor2: '#222222'
+      }
+    }
+  };
+  const segments = getWheelSegments(campaign);
+  assert.equal(segments[0].color, '#111111');
+  assert.equal(segments[1].color, '#222222');
+});
+
+test('getWheelDimensions returns expected pointer size', () => {
+  const dims = getWheelDimensions({ width: 300, height: 300 }, 'center', false);
+  assert.ok(dims.pointerSize >= 30);
+});


### PR DESCRIPTION
## Summary
- update README testing instructions
- run all unit tests via npm test
- add unit tests for utilities and stores

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bfec53b84832ab5862d6c9859bc5b