### PR TITLE
Fix plus button in ModernEditor preview

### DIFF
--- a/src/components/ModernEditor/ModernEditorCanvas.tsx
+++ b/src/components/ModernEditor/ModernEditorCanvas.tsx
@@ -184,7 +184,7 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
         </div>
 
         {/* Floating action button - Canva style */}
-        <div className="absolute bottom-8 right-8">
+        <div className="absolute bottom-8 right-8" style={{ zIndex: 20 }}>
           <div className="relative">
             {/* Add menu */}
             {showAddMenu && (
@@ -221,7 +221,7 @@ const ModernEditorCanvas: React.FC<ModernEditorCanvasProps> = ({
         </div>
 
         {/* Grid toggle */}
-        <div className="absolute top-6 right-6">
+        <div className="absolute top-6 right-6" style={{ zIndex: 20 }}>
           <GridToggle
             showGridLines={showGridLines}
             onToggle={() => setShowGridLines(!showGridLines)}


### PR DESCRIPTION
## Summary
- raise z-index for the floating action button and grid toggle so they appear above the preview overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c06e2f0c4832aaff725fa27bd8544