### PR TITLE
Unify page headers with dashboard layout

### DIFF
--- a/src/components/Layout/PageHeader.tsx
+++ b/src/components/Layout/PageHeader.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  actions?: React.ReactNode;
+}
+
+const PageHeader: React.FC<PageHeaderProps> = ({ title, actions }) => (
+  <div className="bg-white shadow-sm border-b border-gray-200">
+    <div className="px-6 py-4 flex items-center justify-between">
+      <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
+      {actions && <div className="flex space-x-3">{actions}</div>}
+    </div>
+  </div>
+);
+
+export default PageHeader;

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { User, Mail, Lock, Building, BellRing, Shield, UserCircle, Plus } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 const Account: React.FC = () => {
   const [activeTab, setActiveTab] = useState('profile');
 
@@ -16,28 +17,15 @@ const Account: React.FC = () => {
     // In a real app, this would update the profile
   };
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Paramètres du compte</h1>
-          <div className="flex space-x-2">
-            <button className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl mb-3">
-              <Plus className="w-5 h-5 mr-2" />
-              Ajouter un utilisateur
-            </button>
-          </div>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+      <PageHeader
+        title="Paramètres du compte"
+        actions={
+          <button className="btn-secondary rounded-full flex items-center">
+            <Plus className="w-5 h-5 mr-2" />
+            Ajouter un utilisateur
+          </button>
+        }
+      />
 
       <div className="px-6">
         <div className="max-w-5xl mx-auto">

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Search, Plus, Filter, Eye, Copy, Archive, Trash2, ChevronDown, BarChart2, ExternalLink, MoreVertical, Zap } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 import { getCampaignTypeIcon, CampaignType } from '../utils/campaignTypes';
 
 interface ActionModalProps {
@@ -170,43 +171,27 @@ const Campaigns: React.FC = () => {
     setSelectedCampaign(campaign);
   };
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        {/* Background pattern */}
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        {/* Content */}
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-white mb-3">Campagnes</h1>
-          </div>
-          <div className="flex items-center space-x-3 mb-3">
-            <Link 
-              to="/quick-campaign" 
-              className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-yellow-400 to-orange-500 text-white font-medium rounded-xl hover:from-yellow-500 hover:to-orange-600 transition-all duration-200 shadow-lg hover:shadow-xl"
+      <PageHeader
+        title="Campagnes"
+        actions={
+          <div className="flex items-center space-x-3">
+            <Link
+              to="/quick-campaign"
+              className="btn-secondary rounded-full flex items-center"
             >
               <Zap className="w-5 h-5 mr-2" />
               Création rapide
             </Link>
-            <Link 
-              to="/campaign/new" 
-              className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl"
+            <Link
+              to="/campaign/new"
+              className="btn-secondary rounded-full flex items-center"
             >
               <Plus className="w-5 h-5 mr-2" />
               Éditeur avancé
             </Link>
           </div>
-        </div>
-
-        {/* Decorative bottom curve */}
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6">
         <div className="bg-white rounded-xl shadow-sm mt-6">

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Search, Download, Upload, Plus, ChevronDown, ChevronUp, UserCircle, X } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 interface Contact {
   id: string;
   name: string;
@@ -101,37 +102,21 @@ const Contacts: React.FC = () => {
     setShowImportModal(false);
   };
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        {/* Background pattern */}
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        {/* Content */}
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-white mb-3">Contacts</h1>
-          </div>
-          <div className="flex space-x-3">
-            <button onClick={() => setShowImportModal(true)} className="inline-flex items-center px-4 py-2 bg-white/20 text-white font-medium rounded-xl hover:bg-white/30 transition-all duration-200 mb-3">
+      <PageHeader
+        title="Contacts"
+        actions={
+          <>
+            <button onClick={() => setShowImportModal(true)} className="btn-secondary rounded-full flex items-center">
               <Upload className="w-5 h-5 mr-2" />
               Importer
             </button>
-            <button onClick={() => setShowCreateModal(true)} className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl mb-3">
+            <button onClick={() => setShowCreateModal(true)} className="btn-secondary rounded-full flex items-center">
               <Plus className="w-5 h-5 mr-2" />
               Créer contact
             </button>
-          </div>
-        </div>
-
-        {/* Decorative bottom curve */}
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       <div className="px-6">
         <div className="bg-white rounded-xl shadow-sm mt-6">

--- a/src/pages/Data.tsx
+++ b/src/pages/Data.tsx
@@ -1,30 +1,24 @@
 import React, { useState } from 'react';
 import { Download, Filter, RefreshCw } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 const Data: React.FC = () => {
   const [selectedCampaign, setSelectedCampaign] = useState('');
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Données</h1>
-          <select value={selectedCampaign} onChange={e => setSelectedCampaign(e.target.value)} className="w-64 bg-white/90 backdrop-blur-sm border-0 text-gray-700 py-2 px-4 rounded-xl focus:outline-none focus:ring-2 focus:ring-white/20 mb-3">
+      <PageHeader
+        title="Données"
+        actions={
+          <select
+            value={selectedCampaign}
+            onChange={e => setSelectedCampaign(e.target.value)}
+            className="w-64 bg-white border-gray-300 text-gray-700 py-2 px-4 rounded-xl"
+          >
             <option value="">Sélectionner une campagne</option>
             <option value="1">Quiz Marketing Digital</option>
             <option value="2">Roue de la fortune Soldes</option>
             <option value="3">Carte à gratter</option>
           </select>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6 space-y-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Gamepad2, Dices, Cookie, Sparkles, Plus, FormInput, Grid3X3, FlipHorizontal2, Coins } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import PageHeader from '../components/Layout/PageHeader';
 import { CampaignType } from '../utils/campaignTypes';
 const Gamification: React.FC = () => {
   const gamificationTypes = [
@@ -63,29 +64,18 @@ const Gamification: React.FC = () => {
   ];
   return (
     <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Gamification</h1>
+      <PageHeader
+        title="Gamification"
+        actions={
           <Link
             to="/modern-campaign/new?type=wheel"
-            className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl mb-3"
+            className="btn-secondary rounded-full flex items-center"
           >
             <Plus className="w-5 h-5 mr-2" />
             Nouveau Jeu
           </Link>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6 space-y-8">
         <div className="bg-white rounded-xl shadow-sm p-6 mt-6">

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -4,6 +4,7 @@ import { Eye, Send, Save } from 'lucide-react';
 import { ModulesList } from '../components/Newsletter/ModulesList';
 import { EditorCanvas } from '../components/Newsletter/EditorCanvas';
 import { PropertiesPanel } from '../components/Newsletter/PropertiesPanel';
+import PageHeader from '../components/Layout/PageHeader';
 import { useNewsletterStore } from '../stores/newsletterStore';
 import NewsletterPreviewModal from '../components/Newsletter/NewsletterPreviewModal';
 import { SettingsTab } from '@/components/Newsletter/properties/Tab/SettingsTab';
@@ -39,33 +40,25 @@ const Newsletter: React.FC = () => {
     }
   };
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Éditeur de Newsletter</h1>
-          <div className="flex space-x-3">
-            <button onClick={() => setShowPreviewModal(true)} className="inline-flex items-center px-4 py-2 bg-white/20 text-white font-medium rounded-xl hover:bg-white/30 mb-3">
-              <Eye className="w-5 h-5 mr-2" /> Aperçu
+      <PageHeader
+        title="Éditeur de Newsletter"
+        actions={
+          <>
+            <button onClick={() => setShowPreviewModal(true)} className="btn-secondary rounded-full flex items-center">
+              <Eye className="w-5 h-5 mr-2" />
+              Aperçu
             </button>
-            <button className="inline-flex items-center px-4 py-2 bg-white/20 text-white font-medium rounded-xl hover:bg-white/30 mb-3">
-              <Save className="w-5 h-5 mr-2" /> Enregistrer
+            <button className="btn-secondary rounded-full flex items-center">
+              <Save className="w-5 h-5 mr-2" />
+              Enregistrer
             </button>
-            <button className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 shadow-lg mb-3">
-              <Send className="w-5 h-5 mr-2" /> Envoyer
+            <button className="btn-secondary rounded-full flex items-center">
+              <Send className="w-5 h-5 mr-2" />
+              Envoyer
             </button>
-          </div>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       <div className="bg-[#ebf4f7] border-b border-gray-300">
         <div className="max-w-7xl mx-auto px-6">

--- a/src/pages/Social.tsx
+++ b/src/pages/Social.tsx
@@ -1,27 +1,17 @@
 import React from 'react';
 import { BarChart2, AlertCircle, Plus } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 const Social: React.FC = () => {
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Réseaux sociaux</h1>
-          <button className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl mb-3">
+      <PageHeader
+        title="Réseaux sociaux"
+        actions={
+          <button className="btn-secondary rounded-full flex items-center">
             <Plus className="w-5 h-5 mr-2" />
             Nouvelle Publication
           </button>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6 space-y-6">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,37 +1,30 @@
 import React, { useState } from 'react';
 import { BarChart3, LineChart, PieChart, Users, Target, ArrowUpRight, Calendar, Download } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 const Statistics: React.FC = () => {
   const [period, setPeriod] = useState('30');
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Statistiques</h1>
+      <PageHeader
+        title="Statistiques"
+        actions={
           <div className="flex space-x-2">
-            <select value={period} onChange={e => setPeriod(e.target.value)} className="bg-white/90 backdrop-blur-sm border-0 text-gray-700 py-2 px-4 rounded-xl focus:outline-none focus:ring-2 focus:ring-white/20 mb-3">
+            <select
+              value={period}
+              onChange={e => setPeriod(e.target.value)}
+              className="bg-white border-gray-300 text-gray-700 py-2 px-4 rounded-xl"
+            >
               <option value="7">7 derniers jours</option>
               <option value="30">30 derniers jours</option>
               <option value="90">90 derniers jours</option>
               <option value="365">Cette année</option>
             </select>
-            
-            <button className="px-4 py-2 bg-white/90 backdrop-blur-sm border-0 text-gray-700 rounded-xl hover:bg-white transition-colors duration-200 flex items-center mb-3">
+            <button className="btn-secondary rounded-full flex items-center">
               <Download className="w-5 h-5 mr-2" />
               Exporter
             </button>
           </div>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6 space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">

--- a/src/pages/Studies.tsx
+++ b/src/pages/Studies.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Calendar, Download, ChevronRight } from 'lucide-react';
+import PageHeader from '../components/Layout/PageHeader';
 const Studies: React.FC = () => {
   const [selectedEvent, setSelectedEvent] = useState<string[]>([]);
   const marketingEvents = [{
@@ -23,26 +24,15 @@ const Studies: React.FC = () => {
     setSelectedEvent(prev => prev.includes(id) ? prev.filter(eventId => eventId !== id) : [...prev, id]);
   };
   return <div className="-mx-6 -mt-6">
-      <div className="relative h-[100px] bg-[#841b60] overflow-hidden">
-        <div className="absolute inset-10 opacity-[0.15]" style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-        backgroundSize: '60px 60px'
-      }} />
-        
-        <div className="relative h-full max-w-7xl mx-auto px-6 flex items-center justify-between">
-          <h1 className="text-3xl font-bold text-white mb-3">Études</h1>
-          <button className="inline-flex items-center px-6 py-3 bg-white text-[#841b60] font-medium rounded-xl hover:bg-white/90 transition-all duration-200 shadow-lg hover:shadow-xl mb-3">
+      <PageHeader
+        title="Études"
+        actions={
+          <button className="btn-secondary rounded-full flex items-center">
             <Download className="w-5 h-5 mr-2" />
             Télécharger le rapport
           </button>
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0">
-          <svg viewBox="0 0 1440 116" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full" preserveAspectRatio="none" height="10">
-            <path d="M0 116L60 96.3C120 76.7 240 37.3 360 21.7C480 6 600 14 720 34.7C840 55.3 960 89.7 1080 96.3C1200 103 1320 82 1380 71.5L1440 61V116H1380C1320 116 1200 116 1080 116C960 116 840 116 720 116C600 116 480 116 360 116C240 116 120 116 60 116H0Z" fill="#ebf4f7" />
-          </svg>
-        </div>
-      </div>
+        }
+      />
 
       <div className="px-6 space-y-6">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">


### PR DESCRIPTION
## Summary
- add a reusable `PageHeader` component
- refactor all main pages to use `PageHeader`

## Testing
- `npm test` *(fails: needs tsx package installation)*

------
https://chatgpt.com/codex/tasks/task_e_684c202c7290832aaeb439ca8e8528fa