### PR TITLE
fix: make all config panels and sidebars fully responsive, prevent all horizontal overflow and cut-off UI

### DIFF
--- a/src/components/ModernEditor/ModernEditorLayout.tsx
+++ b/src/components/ModernEditor/ModernEditorLayout.tsx
@@ -54,7 +54,7 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
   };
 
   return (
-    <div className="h-screen flex bg-gradient-to-br from-gray-50 to-gray-100 overflow-hidden">
+    <div className="min-h-screen flex bg-gradient-to-br from-gray-50 to-gray-100 overflow-x-hidden">
       {/* Header - Fixed top bar */}
       <div className="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-md border-b border-gray-200/50 shadow-sm">
         <div className="flex items-center justify-between px-4 md:px-6 py-3">
@@ -185,8 +185,8 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
               exit={{ x: -400, opacity: 0 }}
               transition={{ type: "spring", stiffness: 300, damping: 30 }}
               className={`${
-                isMobilePanelOpen ? 'fixed' : 'hidden md:flex'
-              } w-80 lg:w-96 bg-white/95 backdrop-blur-md border-r border-gray-200/50 shadow-xl z-40 h-full overflow-hidden relative`}
+                isMobilePanelOpen ? 'fixed inset-0 w-full max-w-full sm:max-w-sm' : 'hidden md:flex'
+              } md:w-72 lg:w-80 xl:w-96 bg-white/95 backdrop-blur-md border-r border-gray-200/50 shadow-xl z-40 h-full overflow-y-auto relative`}
             >
               {/* Panel collapse button - desktop only */}
               <button
@@ -204,9 +204,9 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
                 <X className="w-5 h-5" />
               </button>
 
-              <div className="flex h-full">
+              <div className="flex h-full min-w-0">
                 {/* Sidebar tabs */}
-                <div className="w-20 border-r border-gray-200/50">
+                <div className="w-20 flex-shrink-0 border-r border-gray-200/50">
                   <ModernEditorSidebar
                     activeTab={activeTab}
                     onTabChange={onTabChange}
@@ -215,7 +215,7 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
                 </div>
 
                 {/* Panel content */}
-                <div className="flex-1 overflow-y-auto">
+                <div className="flex-1 overflow-y-auto min-w-0">
                   <ModernEditorPanel
                     activeTab={activeTab}
                     campaign={campaign}

--- a/src/components/ModernEditor/ModernGeneralTab.tsx
+++ b/src/components/ModernEditor/ModernGeneralTab.tsx
@@ -77,7 +77,7 @@ const ModernGeneralTab: React.FC<ModernGeneralTabProps> = ({
       </div>
 
       {/* Dates */}
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="space-y-2">
           <label className="flex items-center text-sm font-medium text-gray-700">
             <Calendar className="w-4 h-4 mr-2" />
@@ -105,7 +105,7 @@ const ModernGeneralTab: React.FC<ModernGeneralTabProps> = ({
       </div>
 
       {/* Heures */}
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="space-y-2">
           <label className="flex items-center text-sm font-medium text-gray-700">
             <Clock className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- tweak editor layout container for vertical scrolling and safer width
- allow editor side panel to shrink and scroll vertically
- prevent panel content shrinkage
- make general tab date/time grids responsive

## Testing
- `npm run test` *(fails: requests to install dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c3e89c974832abe1402e7422bb2e8