### PR TITLE
Add playable quiz support

### DIFF
--- a/src/components/GameFunnel.tsx
+++ b/src/components/GameFunnel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Color from 'color';
-import { Quiz, Memory, Puzzle } from './GameTypes';
+import { QuizGame, Memory, Puzzle } from './GameTypes';
 
 interface GameFunnelProps {
   campaign: any;
@@ -36,7 +36,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
   const getGameComponent = () => {
     switch (campaign.type) {
       case 'quiz':
-        return <Quiz config={campaign.gameConfig.quiz} onConfigChange={() => {}} />;
+        return (
+          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+        );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;
       case 'puzzle':

--- a/src/components/GameTypes/QuizGame.tsx
+++ b/src/components/GameTypes/QuizGame.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useGameResult } from '../../hooks/useGameResult';
+
+interface QuizGameProps {
+  campaignId: string;
+  config: any;
+}
+
+const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
+  const questions = config.questions || [];
+  const { checkWinningCondition, saveResult } = useGameResult(campaignId, config);
+  const [current, setCurrent] = useState(0);
+  const [answers, setAnswers] = useState<number[]>([]);
+  const [completed, setCompleted] = useState(false);
+
+  const handleAnswer = async (index: number) => {
+    const newAnswers = [...answers, index];
+    if (current + 1 < questions.length) {
+      setAnswers(newAnswers);
+      setCurrent(current + 1);
+    } else {
+      const finalAnswers = newAnswers;
+      const score = questions.reduce((acc: number, q: any, i: number) => {
+        const option = q.options?.[finalAnswers[i]];
+        return acc + (option && option.isCorrect ? 1 : 0);
+      }, 0);
+      const isWinner = await checkWinningCondition();
+      await saveResult({
+        campaignId,
+        userId: 'anonymous',
+        gameType: 'quiz',
+        result: finalAnswers,
+        score,
+        isWinner,
+      });
+      setAnswers(finalAnswers);
+      setCompleted(true);
+    }
+  };
+
+  if (completed) {
+    return <div className="text-center p-4">Merci d\'avoir participé !</div>;
+  }
+
+  const question = questions[current];
+  if (!question) {
+    return <div className="text-center p-4">Aucune question configurée</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-medium">{question.text}</h3>
+      {question.options?.map((option: any, idx: number) => (
+        <button
+          key={option.id}
+          onClick={() => handleAnswer(idx)}
+          className="block w-full px-4 py-2 bg-[#841b60] text-white rounded-lg hover:bg-[#6d164f]"
+        >
+          {option.text}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default QuizGame;

--- a/src/components/GameTypes/index.ts
+++ b/src/components/GameTypes/index.ts
@@ -6,4 +6,5 @@ export { default as Memory } from './Memory';
 export { default as Puzzle } from './Puzzle';
 export { default as Dice } from './Dice';
 export { default as Jackpot } from './Jackpot';
+export { default as QuizGame } from './QuizGame';
 export { default as GameRenderer } from '../CampaignEditor/GameRenderer';

--- a/src/components/funnels/FunnelStandard.tsx
+++ b/src/components/funnels/FunnelStandard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Color from 'color';
 import DynamicContactForm from '../forms/DynamicContactForm';
-import { Quiz, Memory, Puzzle } from '../GameTypes';
+import { QuizGame, Memory, Puzzle } from '../GameTypes';
 import { useParticipations } from '../../hooks/useParticipations';
 
 const DEFAULT_FIELDS = [
@@ -60,7 +60,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
   const getGameComponent = () => {
     switch (campaign.type) {
       case 'quiz':
-        return <Quiz config={campaign.gameConfig.quiz} onConfigChange={() => {}} />;
+        return (
+          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+        );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;
       case 'puzzle':

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ContrastBackground from '../../common/ContrastBackground';
 import ValidationMessage from '../../common/ValidationMessage';
 import WheelPreview from '../../GameTypes/WheelPreview';
-import { Jackpot } from '../../GameTypes';
+import { Jackpot, QuizGame } from '../../GameTypes';
 import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import { GAME_SIZES, GameSize } from '../../configurators/GameSizeSelector';
@@ -111,13 +111,20 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             slotBorderWidth={campaign.gameConfig?.jackpot?.slotBorderWidth}
             slotBackgroundColor={campaign.gameConfig?.jackpot?.slotBackgroundColor}
             onFinish={handleGameComplete}
-            onStart={handleGameStartInternal}
+          onStart={handleGameStartInternal}
+        />
+      );
+      case 'quiz':
+        return (
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig?.quiz || {}}
           />
         );
       case 'dice':
         return (
-          <DicePreview 
-            config={campaign.gameConfig?.dice || {}} 
+          <DicePreview
+            config={campaign.gameConfig?.dice || {}}
           />
         );
       default:

--- a/src/pages/CampaignEditor.tsx
+++ b/src/pages/CampaignEditor.tsx
@@ -192,6 +192,16 @@ const CampaignEditor: React.FC = () => {
     }
   };
   const handleSave = async (continueEditing = false) => {
+    if (campaign.type === 'quiz') {
+      const questions = campaign.gameConfig?.quiz?.questions || [];
+      const valid = questions.every((q: any) =>
+        Array.isArray(q.options) && q.options.length >= 2 && q.options.some((o: any) => o.isCorrect)
+      );
+      if (!valid) {
+        alert('Chaque question doit comporter au moins deux options et une réponse correcte.');
+        return;
+      }
+    }
     const campaignData = {
       ...campaign,
       form_fields: campaign.formFields

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -159,6 +159,17 @@ const ModernCampaignEditor: React.FC = () => {
   const handleSave = async (continueEditing = false) => {
     setIsLoading(true);
     try {
+      if (campaign.type === 'quiz') {
+        const questions = campaign.gameConfig?.quiz?.questions || [];
+        const valid = questions.every((q: any) =>
+          Array.isArray(q.options) && q.options.length >= 2 && q.options.some((o: any) => o.isCorrect)
+        );
+        if (!valid) {
+          alert('Chaque question doit comporter au moins deux options et une réponse correcte.');
+          setIsLoading(false);
+          return;
+        }
+      }
       const campaignData = {
         ...campaign,
         form_fields: campaign.formFields

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -66,4 +66,4 @@ export interface JackpotConfig extends GameConfig {
 }
 
 // ----------- AJOUT TYPE GAME "JACKPOT" -----------
-export type GameType = 'wheel' | 'scratch' | 'memory' | 'puzzle' | 'dice' | 'jackpot';
+export type GameType = 'wheel' | 'scratch' | 'memory' | 'puzzle' | 'dice' | 'jackpot' | 'quiz';


### PR DESCRIPTION
## Summary
- allow `quiz` as a `GameType`
- add new `QuizGame` component for playing a quiz
- render `QuizGame` in funnel components
- validate quiz questions on save

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c87121488832a99faced2f76bbf68