### PR TITLE
Add playable quiz support

### DIFF
--- a/src/components/CampaignEditor/CampaignContent.tsx
+++ b/src/components/CampaignEditor/CampaignContent.tsx
@@ -17,6 +17,10 @@ const CampaignContent: React.FC<CampaignContentProps> = ({
   setCampaign,
 }) => {
   const [activeSection, setActiveSection] = useState<'game' | 'visual'>('game');
+  const [activeQuizQuestion, setActiveQuizQuestion] = useState(0);
+  const [previewQuestion, setPreviewQuestion] = useState<any>(
+    campaign.gameConfig?.quiz?.questions?.[0]
+  );
 
   const updateGameConfig = (gameType: string, config: any) => {
     setCampaign((prev: any) => ({
@@ -35,6 +39,9 @@ const CampaignContent: React.FC<CampaignContentProps> = ({
           <Quiz
             config={campaign.gameConfig?.quiz}
             onConfigChange={(config) => updateGameConfig('quiz', config)}
+            activeQuestion={activeQuizQuestion}
+            onActiveQuestionChange={setActiveQuizQuestion}
+            onQuestionChange={setPreviewQuestion}
           />
         );
       case 'wheel':
@@ -120,8 +127,8 @@ const CampaignContent: React.FC<CampaignContentProps> = ({
               <Eye className="w-5 h-5 text-[#841b60]" />
               <h3 className="text-lg font-medium text-gray-900">Aperçu du jeu</h3>
             </div>
-            <GameCanvasPreview 
-              campaign={campaign} 
+            <GameCanvasPreview
+              campaign={{ ...campaign, activeQuizQuestion, previewQuestion }}
               gameSize={campaign.gameSize || 'large'}
             />
           </div>
@@ -142,8 +149,8 @@ const CampaignContent: React.FC<CampaignContentProps> = ({
                 <Eye className="w-5 h-5 text-[#841b60]" />
                 <h3 className="text-lg font-medium text-gray-900">Aperçu du jeu</h3>
               </div>
-              <GameCanvasPreview 
-                campaign={campaign} 
+              <GameCanvasPreview
+                campaign={{ ...campaign, activeQuizQuestion, previewQuestion }}
                 gameSize={campaign.gameSize || 'large'}
               />
 

--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import Jackpot from '../GameTypes/Jackpot';
-import { Quiz } from '../GameTypes';
+import { QuizPreview } from '../GameTypes';
 import WheelPreview from '../GameTypes/WheelPreview';
 import MemoryPreview from '../GameTypes/MemoryPreview';
 import PuzzlePreview from '../GameTypes/PuzzlePreview';
@@ -69,7 +69,12 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       return (
         <div style={{ ...containerStyle, minHeight: '400px', padding: '20px', boxSizing: 'border-box' }}>
           <div style={{ ...wrapperStyle, ...getPositionStyles() }}>
-            <Quiz config={campaign.gameConfig?.quiz || {}} onConfigChange={() => {}} />
+            <QuizPreview
+              question={
+                campaign.previewQuestion ||
+                campaign.gameConfig?.quiz?.questions?.[campaign.activeQuizQuestion ?? 0]
+              }
+            />
           </div>
         </div>
       );

--- a/src/components/GameFunnel.tsx
+++ b/src/components/GameFunnel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Color from 'color';
-import { Quiz, Memory, Puzzle } from './GameTypes';
+import { QuizGame, Memory, Puzzle } from './GameTypes';
 
 interface GameFunnelProps {
   campaign: any;
@@ -36,7 +36,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
   const getGameComponent = () => {
     switch (campaign.type) {
       case 'quiz':
-        return <Quiz config={campaign.gameConfig.quiz} onConfigChange={() => {}} />;
+        return (
+          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+        );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;
       case 'puzzle':

--- a/src/components/GameTypes/Quiz.tsx
+++ b/src/components/GameTypes/Quiz.tsx
@@ -1,18 +1,36 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Plus, Trash2, Image as ImageIcon, Type, Clock } from 'lucide-react';
+import QuizPreview from './QuizPreview';
 
 interface QuizProps {
   config: any;
   onConfigChange: (config: any) => void;
+  activeQuestion?: number;
+  onActiveQuestionChange?: (index: number) => void;
+  onQuestionChange?: (question: any) => void;
 }
 
-const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
-  const [activeQuestion, setActiveQuestion] = useState(0);
+const Quiz: React.FC<QuizProps> = ({
+  config,
+  onConfigChange,
+  activeQuestion: externalActive,
+  onActiveQuestionChange,
+  onQuestionChange
+}) => {
+  const [internalActive, setInternalActive] = useState(externalActive ?? 0);
+  const activeQuestion = externalActive ?? internalActive;
+  const setActiveQuestion = onActiveQuestionChange ?? setInternalActive;
 
   // Ensure config has a default structure
-  const safeConfig = config || { questions: [] };
-  const questions = safeConfig.questions || [];
+const safeConfig = config || { questions: [] };
+const questions = safeConfig.questions || [];
+
+useEffect(() => {
+  if (onQuestionChange) {
+    onQuestionChange(questions[activeQuestion]);
+  }
+}, [activeQuestion, questions, onQuestionChange]);
 
   const addQuestion = () => {
     const newConfig = {
@@ -38,6 +56,9 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
     };
     onConfigChange(newConfig);
     setActiveQuestion(newConfig.questions.length - 1);
+    if (onQuestionChange) {
+      onQuestionChange(newConfig.questions[newConfig.questions.length - 1]);
+    }
   };
 
   const removeQuestion = (index: number) => {
@@ -46,6 +67,9 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
     onConfigChange({ ...safeConfig, questions: newQuestions });
     if (activeQuestion >= newQuestions.length) {
       setActiveQuestion(Math.max(0, newQuestions.length - 1));
+    }
+    if (onQuestionChange) {
+      onQuestionChange(newQuestions[Math.max(0, newQuestions.length - 1)]);
     }
   };
 
@@ -56,6 +80,9 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
       [field]: value
     };
     onConfigChange({ ...safeConfig, questions: newQuestions });
+    if (onQuestionChange) {
+      onQuestionChange(newQuestions[activeQuestion]);
+    }
   };
 
   const addOption = (questionIndex: number) => {
@@ -66,12 +93,18 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
       isCorrect: false
     });
     onConfigChange({ ...safeConfig, questions: newQuestions });
+    if (onQuestionChange) {
+      onQuestionChange(newQuestions[questionIndex]);
+    }
   };
 
   const removeOption = (questionIndex: number, optionIndex: number) => {
     const newQuestions = [...questions];
     newQuestions[questionIndex].options.splice(optionIndex, 1);
     onConfigChange({ ...safeConfig, questions: newQuestions });
+    if (onQuestionChange) {
+      onQuestionChange(newQuestions[questionIndex]);
+    }
   };
 
   const updateOption = (questionIndex: number, optionIndex: number, field: string, value: any) => {
@@ -81,6 +114,9 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
       [field]: value
     };
     onConfigChange({ ...safeConfig, questions: newQuestions });
+    if (onQuestionChange) {
+      onQuestionChange(newQuestions[questionIndex]);
+    }
   };
 
   // If no questions exist, show empty state
@@ -105,7 +141,12 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
         {questions.map((question: any, index: number) => (
           <button
             key={question.id}
-            onClick={() => setActiveQuestion(index)}
+            onClick={() => {
+              setActiveQuestion(index);
+              if (onQuestionChange) {
+                onQuestionChange(questions[index]);
+              }
+            }}
             className={`flex items-center px-4 py-2 rounded-lg whitespace-nowrap ${
               activeQuestion === index
                 ? 'bg-[#841b60] text-white'
@@ -124,27 +165,29 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
         </button>
       </div>
 
-      {questions[activeQuestion] && (
-        <div className="space-y-6">
-          <div className="flex justify-between items-start">
-            <div className="flex-1 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Question
-                </label>
-                <div className="relative">
-                  <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                    <Type className="w-5 h-5 text-gray-400" />
+      <div className="grid md:grid-cols-2 gap-6">
+        {questions[activeQuestion] ? (
+          <>
+            <div className="space-y-6">
+              <div className="flex justify-between items-start">
+                <div className="flex-1 space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Question
+                    </label>
+                    <div className="relative">
+                      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                        <Type className="w-5 h-5 text-gray-400" />
+                      </div>
+                      <input
+                        type="text"
+                        value={questions[activeQuestion].text}
+                        onChange={(e) => updateQuestion(activeQuestion, 'text', e.target.value)}
+                        className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+                        placeholder="Saisissez votre question"
+                      />
+                    </div>
                   </div>
-                  <input
-                    type="text"
-                    value={questions[activeQuestion].text}
-                    onChange={(e) => updateQuestion(activeQuestion, 'text', e.target.value)}
-                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
-                    placeholder="Saisissez votre question"
-                  />
-                </div>
-              </div>
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -198,92 +241,99 @@ const Quiz: React.FC<QuizProps> = ({ config, onConfigChange }) => {
               </div>
             </div>
 
-            <button
-              onClick={() => removeQuestion(activeQuestion)}
-              className="ml-4 p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors duration-200"
-              disabled={questions.length === 1}
-            >
-              <Trash2 className="w-5 h-5" />
-            </button>
-          </div>
+                <button
+                  onClick={() => removeQuestion(activeQuestion)}
+                  className="ml-4 p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors duration-200"
+                  disabled={questions.length === 1}
+                >
+                  <Trash2 className="w-5 h-5" />
+                </button>
+              </div>
 
-          <div>
-            <div className="flex items-center justify-between mb-4">
-              <label className="block text-sm font-medium text-gray-700">
-                Options de réponse
-              </label>
-              <button
-                onClick={() => addOption(activeQuestion)}
-                className="text-sm text-[#841b60] hover:text-[#6d164f] font-medium flex items-center"
-              >
-                <Plus className="w-4 h-4 mr-1" />
-                Ajouter une option
-              </button>
-            </div>
-
-            <div className="space-y-3">
-              {questions[activeQuestion].options?.map((option: any, optionIndex: number) => (
-                <div key={option.id} className="flex items-center space-x-3">
-                  <input
-                    type={questions[activeQuestion].type === 'multiple' ? 'checkbox' : 'radio'}
-                    checked={option.isCorrect}
-                    onChange={(e) => updateOption(activeQuestion, optionIndex, 'isCorrect', e.target.checked)}
-                    className="w-5 h-5 text-[#841b60] border-gray-300 focus:ring-[#841b60]"
-                  />
-                  <input
-                    type="text"
-                    value={option.text}
-                    onChange={(e) => updateOption(activeQuestion, optionIndex, 'text', e.target.value)}
-                    className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
-                    placeholder={`Option ${optionIndex + 1}`}
-                  />
+              <div>
+                <div className="flex items-center justify-between mb-4">
+                  <label className="block text-sm font-medium text-gray-700">
+                    Options de réponse
+                  </label>
                   <button
-                    onClick={() => removeOption(activeQuestion, optionIndex)}
-                    className="p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors duration-200"
-                    disabled={questions[activeQuestion].options?.length <= 2}
+                    onClick={() => addOption(activeQuestion)}
+                    className="text-sm text-[#841b60] hover:text-[#6d164f] font-medium flex items-center"
                   >
-                    <Trash2 className="w-4 h-4" />
+                    <Plus className="w-4 h-4 mr-1" />
+                    Ajouter une option
                   </button>
                 </div>
-              ))}
-            </div>
-          </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Message réponse correcte
-              </label>
-              <input
-                type="text"
-                value={questions[activeQuestion].feedback?.correct || ''}
-                onChange={(e) => updateQuestion(activeQuestion, 'feedback', {
-                  ...questions[activeQuestion].feedback,
-                  correct: e.target.value
-                })}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
-                placeholder="Bravo !"
-              />
-            </div>
+                <div className="space-y-3">
+                  {questions[activeQuestion].options?.map((option: any, optionIndex: number) => (
+                    <div key={option.id} className="flex items-center space-x-3">
+                      <input
+                        type={questions[activeQuestion].type === 'multiple' ? 'checkbox' : 'radio'}
+                        checked={option.isCorrect}
+                        onChange={(e) => updateOption(activeQuestion, optionIndex, 'isCorrect', e.target.checked)}
+                        className="w-5 h-5 text-[#841b60] border-gray-300 focus:ring-[#841b60]"
+                      />
+                      <input
+                        type="text"
+                        value={option.text}
+                        onChange={(e) => updateOption(activeQuestion, optionIndex, 'text', e.target.value)}
+                        className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+                        placeholder={`Option ${optionIndex + 1}`}
+                      />
+                      <button
+                        onClick={() => removeOption(activeQuestion, optionIndex)}
+                        className="p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors duration-200"
+                        disabled={questions[activeQuestion].options?.length <= 2}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Message réponse incorrecte
-              </label>
-              <input
-                type="text"
-                value={questions[activeQuestion].feedback?.incorrect || ''}
-                onChange={(e) => updateQuestion(activeQuestion, 'feedback', {
-                  ...questions[activeQuestion].feedback,
-                  incorrect: e.target.value
-                })}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
-                placeholder="Dommage..."
-              />
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Message réponse correcte
+                  </label>
+                  <input
+                    type="text"
+                    value={questions[activeQuestion].feedback?.correct || ''}
+                    onChange={(e) => updateQuestion(activeQuestion, 'feedback', {
+                      ...questions[activeQuestion].feedback,
+                      correct: e.target.value
+                    })}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+                    placeholder="Bravo !"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Message réponse incorrecte
+                  </label>
+                  <input
+                    type="text"
+                    value={questions[activeQuestion].feedback?.incorrect || ''}
+                    onChange={(e) => updateQuestion(activeQuestion, 'feedback', {
+                      ...questions[activeQuestion].feedback,
+                      incorrect: e.target.value
+                    })}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+                    placeholder="Dommage..."
+                  />
+                </div>
+              </div>
             </div>
+            <QuizPreview question={questions[activeQuestion]} />
+          </>
+        ) : (
+          <div className="md:col-span-2 text-center py-12 text-gray-500">
+            Sélectionnez ou ajoutez une question pour la prévisualiser
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/GameTypes/QuizGame.tsx
+++ b/src/components/GameTypes/QuizGame.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useGameResult } from '../../hooks/useGameResult';
+
+interface QuizGameProps {
+  campaignId: string;
+  config: any;
+}
+
+const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
+  const questions = config.questions || [];
+  const { checkWinningCondition, saveResult } = useGameResult(campaignId, config);
+  const [current, setCurrent] = useState(0);
+  const [answers, setAnswers] = useState<number[]>([]);
+  const [completed, setCompleted] = useState(false);
+
+  const handleAnswer = async (index: number) => {
+    const newAnswers = [...answers, index];
+    if (current + 1 < questions.length) {
+      setAnswers(newAnswers);
+      setCurrent(current + 1);
+    } else {
+      const finalAnswers = newAnswers;
+      const score = questions.reduce((acc: number, q: any, i: number) => {
+        const option = q.options?.[finalAnswers[i]];
+        return acc + (option && option.isCorrect ? 1 : 0);
+      }, 0);
+      const isWinner = await checkWinningCondition();
+      await saveResult({
+        campaignId,
+        userId: 'anonymous',
+        gameType: 'quiz',
+        result: finalAnswers,
+        score,
+        isWinner,
+      });
+      setAnswers(finalAnswers);
+      setCompleted(true);
+    }
+  };
+
+  if (completed) {
+    return <div className="text-center p-4">Merci d\'avoir participé !</div>;
+  }
+
+  const question = questions[current];
+  if (!question) {
+    return <div className="text-center p-4">Aucune question configurée</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-medium">{question.text}</h3>
+      {question.options?.map((option: any, idx: number) => (
+        <button
+          key={option.id}
+          onClick={() => handleAnswer(idx)}
+          className="block w-full px-4 py-2 bg-[#841b60] text-white rounded-lg hover:bg-[#6d164f]"
+        >
+          {option.text}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default QuizGame;

--- a/src/components/GameTypes/QuizPreview.tsx
+++ b/src/components/GameTypes/QuizPreview.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+interface QuizPreviewProps {
+  question?: any;
+}
+
+const QuizPreview: React.FC<QuizPreviewProps> = ({ question }) => {
+  if (!question) {
+    return (
+      <div className="flex items-center justify-center text-gray-500 text-sm p-4 border border-gray-200 rounded-lg h-full">
+        Sélectionnez ou ajoutez une question pour la prévisualiser
+      </div>
+    );
+  }
+
+  const { text, image, type, options = [], feedback = {}, timeLimit } = question;
+  const renderOptions = () => {
+    if (type === 'input') {
+      return (
+        <input
+          type="text"
+          disabled
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+          placeholder="Votre réponse"
+        />
+      );
+    }
+    const inputType = type === 'multiple' ? 'checkbox' : 'radio';
+    return (
+      <div className="space-y-2">
+        {options.map((opt: any) => (
+          <label key={opt.id} className="flex items-center space-x-2">
+            <input type={inputType} disabled className="text-[#841b60]" />
+            <span>{opt.text || 'Option'}</span>
+          </label>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4 p-4 border border-gray-200 rounded-lg bg-white">
+      {image && (
+        <img src={image} alt="" className="w-full h-48 object-cover rounded-lg" />
+      )}
+      <h3 className="text-lg font-medium">{text || 'Question'}</h3>
+      {renderOptions()}
+      <div className="text-sm text-gray-400">
+        {(feedback.correct || 'Bonne réponse')} / {(feedback.incorrect || 'Mauvaise réponse')}
+      </div>
+      {timeLimit > 0 && (
+        <div className="text-xs text-gray-500">Temps : {timeLimit}s</div>
+      )}
+    </div>
+  );
+};
+
+export default QuizPreview;

--- a/src/components/GameTypes/index.ts
+++ b/src/components/GameTypes/index.ts
@@ -6,4 +6,6 @@ export { default as Memory } from './Memory';
 export { default as Puzzle } from './Puzzle';
 export { default as Dice } from './Dice';
 export { default as Jackpot } from './Jackpot';
+export { default as QuizGame } from './QuizGame';
+export { default as QuizPreview } from './QuizPreview';
 export { default as GameRenderer } from '../CampaignEditor/GameRenderer';

--- a/src/components/funnels/FunnelStandard.tsx
+++ b/src/components/funnels/FunnelStandard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Color from 'color';
 import DynamicContactForm from '../forms/DynamicContactForm';
-import { Quiz, Memory, Puzzle } from '../GameTypes';
+import { QuizGame, Memory, Puzzle } from '../GameTypes';
 import { useParticipations } from '../../hooks/useParticipations';
 
 const DEFAULT_FIELDS = [
@@ -60,7 +60,9 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
   const getGameComponent = () => {
     switch (campaign.type) {
       case 'quiz':
-        return <Quiz config={campaign.gameConfig.quiz} onConfigChange={() => {}} />;
+        return (
+          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+        );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;
       case 'puzzle':

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ContrastBackground from '../../common/ContrastBackground';
 import ValidationMessage from '../../common/ValidationMessage';
 import WheelPreview from '../../GameTypes/WheelPreview';
-import { Jackpot } from '../../GameTypes';
+import { Jackpot, QuizGame } from '../../GameTypes';
 import ScratchPreview from '../../GameTypes/ScratchPreview';
 import DicePreview from '../../GameTypes/DicePreview';
 import { GAME_SIZES, GameSize } from '../../configurators/GameSizeSelector';
@@ -111,13 +111,20 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             slotBorderWidth={campaign.gameConfig?.jackpot?.slotBorderWidth}
             slotBackgroundColor={campaign.gameConfig?.jackpot?.slotBackgroundColor}
             onFinish={handleGameComplete}
-            onStart={handleGameStartInternal}
+          onStart={handleGameStartInternal}
+        />
+      );
+      case 'quiz':
+        return (
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig?.quiz || {}}
           />
         );
       case 'dice':
         return (
-          <DicePreview 
-            config={campaign.gameConfig?.dice || {}} 
+          <DicePreview
+            config={campaign.gameConfig?.dice || {}}
           />
         );
       default:

--- a/src/pages/CampaignEditor.tsx
+++ b/src/pages/CampaignEditor.tsx
@@ -192,6 +192,16 @@ const CampaignEditor: React.FC = () => {
     }
   };
   const handleSave = async (continueEditing = false) => {
+    if (campaign.type === 'quiz') {
+      const questions = campaign.gameConfig?.quiz?.questions || [];
+      const valid = questions.every((q: any) =>
+        Array.isArray(q.options) && q.options.length >= 2 && q.options.some((o: any) => o.isCorrect)
+      );
+      if (!valid) {
+        alert('Chaque question doit comporter au moins deux options et une réponse correcte.');
+        return;
+      }
+    }
     const campaignData = {
       ...campaign,
       form_fields: campaign.formFields

--- a/src/pages/ModernCampaignEditor.tsx
+++ b/src/pages/ModernCampaignEditor.tsx
@@ -159,6 +159,17 @@ const ModernCampaignEditor: React.FC = () => {
   const handleSave = async (continueEditing = false) => {
     setIsLoading(true);
     try {
+      if (campaign.type === 'quiz') {
+        const questions = campaign.gameConfig?.quiz?.questions || [];
+        const valid = questions.every((q: any) =>
+          Array.isArray(q.options) && q.options.length >= 2 && q.options.some((o: any) => o.isCorrect)
+        );
+        if (!valid) {
+          alert('Chaque question doit comporter au moins deux options et une réponse correcte.');
+          setIsLoading(false);
+          return;
+        }
+      }
       const campaignData = {
         ...campaign,
         form_fields: campaign.formFields

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -66,4 +66,4 @@ export interface JackpotConfig extends GameConfig {
 }
 
 // ----------- AJOUT TYPE GAME "JACKPOT" -----------
-export type GameType = 'wheel' | 'scratch' | 'memory' | 'puzzle' | 'dice' | 'jackpot';
+export type GameType = 'wheel' | 'scratch' | 'memory' | 'puzzle' | 'dice' | 'jackpot' | 'quiz';


### PR DESCRIPTION
## Summary
- allow `quiz` as a `GameType`
- add new `QuizGame` component for playing a quiz
- render `QuizGame` in funnel components
- validate quiz questions on save
- make quiz question preview live and fully synchronized with editor fields
- **synchronize quiz preview in real time when editing questions**

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c87121488832a99faced2f76bbf68