### PR TITLE
Add quiz case in GameSwitcher

### DIFF
--- a/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
+++ b/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import WheelPreview from '../../../GameTypes/WheelPreview';
-import { Jackpot } from '../../../GameTypes';
+import { Jackpot, QuizGame } from '../../../GameTypes';
 import ScratchPreview from '../../../GameTypes/ScratchPreview';
 import DicePreview from '../../../GameTypes/DicePreview';
 import FormPreview from '../../../GameTypes/FormPreview';
@@ -120,12 +120,25 @@ const GameSwitcher: React.FC<GameSwitcherProps> = ({
         </div>
       );
 
+
     case 'dice':
       return (
         <div style={baseContainerStyle}>
           <div style={baseWrapperStyle}>
             <DicePreview
               config={mockCampaign.gameConfig?.dice || {}}
+            />
+          </div>
+        </div>
+      );
+
+    case 'quiz':
+      return (
+        <div style={baseContainerStyle}>
+          <div style={baseWrapperStyle}>
+            <QuizGame
+              campaignId={synchronizedCampaign.id}
+              config={mockCampaign.gameConfig?.quiz || {}}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- import `QuizGame`
- render `QuizGame` when game type is `quiz`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c958f9ad8832a8609e0a2ded64842