### PR TITLE
Add quiz support in newsletter preview

### DIFF
--- a/src/components/Newsletter/PreviewContent.tsx
+++ b/src/components/Newsletter/PreviewContent.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import Color from 'color';
 import confetti from 'canvas-confetti';
-import { Wheel, Scratch, Jackpot } from '../GameTypes';
+import { Wheel, Scratch, Jackpot, QuizGame } from '../GameTypes';
 import MemoryPreview from '../GameTypes/MemoryPreview';
 import PuzzlePreview from '../GameTypes/PuzzlePreview';
 import DicePreview from '../GameTypes/DicePreview';
@@ -59,6 +59,13 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ campaign, step = 'game'
     }
 
     switch (campaign.type) {
+      case 'quiz':
+        return (
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+          />
+        );
       case 'memory':
         return (
           <MemoryPreview


### PR DESCRIPTION
## Summary
- show quiz games in newsletter previews

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c95903880832ab89ac3cad12ca904