### PR TITLE
Fix quiz preview

### DIFF
--- a/src/components/CampaignEditor/PreviewContent.tsx
+++ b/src/components/CampaignEditor/PreviewContent.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Color from 'color';
 import confetti from 'canvas-confetti';
-import { Quiz, Wheel, Scratch, Memory, Puzzle, Dice } from '../GameTypes';
+import { QuizGame, Wheel, Scratch, Memory, Puzzle, Dice } from '../GameTypes';
 import FormPreview from '../GameTypes/FormPreview';
 
 interface PreviewContentProps {
@@ -67,9 +67,10 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ campaign, step = 'game'
     switch (campaign.type) {
       case 'quiz':
         return (
-          <Quiz 
-            config={campaign.gameConfig.quiz} 
-            onConfigChange={() => {}}
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
           />
         );
 

--- a/src/components/GameFunnel.tsx
+++ b/src/components/GameFunnel.tsx
@@ -37,7 +37,11 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
     switch (campaign.type) {
       case 'quiz':
         return (
-          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
+          />
         );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;

--- a/src/components/GameTypes/QuizGame.tsx
+++ b/src/components/GameTypes/QuizGame.tsx
@@ -4,14 +4,20 @@ import { useGameResult } from '../../hooks/useGameResult';
 interface QuizGameProps {
   campaignId: string;
   config: any;
+  design?: any;
 }
 
-const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
+const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {}, design = {} }) => {
   const questions = config.questions || [];
   const { checkWinningCondition, saveResult } = useGameResult(campaignId, config);
   const [current, setCurrent] = useState(0);
   const [answers, setAnswers] = useState<number[]>([]);
   const [completed, setCompleted] = useState(false);
+  const [score, setScore] = useState(0);
+  const [started, setStarted] = useState(!config.introScreen);
+
+  const colors = design.customColors || { primary: '#841b60', text: '#ffffff' };
+  const textStyles = design.textStyles || {};
 
   const handleAnswer = async (index: number) => {
     const newAnswers = [...answers, index];
@@ -20,17 +26,18 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
       setCurrent(current + 1);
     } else {
       const finalAnswers = newAnswers;
-      const score = questions.reduce((acc: number, q: any, i: number) => {
+      const finalScore = questions.reduce((acc: number, q: any, i: number) => {
         const option = q.options?.[finalAnswers[i]];
         return acc + (option && option.isCorrect ? 1 : 0);
       }, 0);
+      setScore(finalScore);
       const isWinner = await checkWinningCondition();
       await saveResult({
         campaignId,
         userId: 'anonymous',
         gameType: 'quiz',
         result: finalAnswers,
-        score,
+        score: finalScore,
         isWinner,
       });
       setAnswers(finalAnswers);
@@ -38,8 +45,37 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
     }
   };
 
+  if (!started) {
+    return (
+      <div className="text-center space-y-4 p-4">
+        <h3 className="text-lg font-medium" style={textStyles.title}>
+          {config.introScreen?.title || 'Bienvenue au quiz'}
+        </h3>
+        {config.introScreen?.description && (
+          <p style={textStyles.description}>{config.introScreen.description}</p>
+        )}
+        <button
+          onClick={() => setStarted(true)}
+          className="px-4 py-2 rounded-lg"
+          style={{ backgroundColor: colors.primary, color: colors.text, ...textStyles.button }}
+        >
+          {config.introScreen?.buttonText || 'Commencer'}
+        </button>
+      </div>
+    );
+  }
+
   if (completed) {
-    return <div className="text-center p-4">Merci d\'avoir participé !</div>;
+    return (
+      <div className="text-center p-4 space-y-2">
+        <h3 className="text-lg font-semibold" style={textStyles.title}>
+          {config.endMessage || 'Félicitations !'}
+        </h3>
+        <p style={textStyles.description}>
+          Vous avez obtenu {score} / {questions.length} points.
+        </p>
+      </div>
+    );
   }
 
   const question = questions[current];
@@ -49,12 +85,16 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium">{question.text}</h3>
+      <p className="text-sm" style={textStyles.label}>
+        Question {current + 1} sur {questions.length}
+      </p>
+      <h3 className="text-lg font-medium" style={textStyles.title}>{question.text}</h3>
       {question.options?.map((option: any, idx: number) => (
         <button
           key={option.id}
           onClick={() => handleAnswer(idx)}
-          className="block w-full px-4 py-2 bg-[#841b60] text-white rounded-lg hover:bg-[#6d164f]"
+          className="block w-full px-4 py-2 rounded-lg transition-colors"
+          style={{ backgroundColor: colors.primary, color: colors.text, ...textStyles.button }}
         >
           {option.text}
         </button>

--- a/src/components/funnels/FunnelStandard.tsx
+++ b/src/components/funnels/FunnelStandard.tsx
@@ -61,7 +61,11 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
     switch (campaign.type) {
       case 'quiz':
         return (
-          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
+          />
         );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -119,6 +119,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
           <QuizGame
             campaignId={campaign.id}
             config={campaign.gameConfig?.quiz || {}}
+            design={campaign.design}
           />
         );
       case 'dice':


### PR DESCRIPTION
## Summary
- update quiz preview to use `QuizGame`
- add intro screen and progress tracking in `QuizGame`
- show final score with campaign styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c959354f0832a865ae13c4995adf9