### PR TITLE
Fix quiz preview

### DIFF
--- a/src/components/CampaignEditor/PreviewContent.tsx
+++ b/src/components/CampaignEditor/PreviewContent.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Color from 'color';
 import confetti from 'canvas-confetti';
-import { Quiz, Wheel, Scratch, Memory, Puzzle, Dice } from '../GameTypes';
+import { QuizGame, Wheel, Scratch, Memory, Puzzle, Dice } from '../GameTypes';
 import FormPreview from '../GameTypes/FormPreview';
 
 interface PreviewContentProps {
@@ -67,9 +67,10 @@ const PreviewContent: React.FC<PreviewContentProps> = ({ campaign, step = 'game'
     switch (campaign.type) {
       case 'quiz':
         return (
-          <Quiz 
-            config={campaign.gameConfig.quiz} 
-            onConfigChange={() => {}}
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
           />
         );
 

--- a/src/components/GameFunnel.tsx
+++ b/src/components/GameFunnel.tsx
@@ -37,7 +37,11 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
     switch (campaign.type) {
       case 'quiz':
         return (
-          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
+          />
         );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;

--- a/src/components/GameTypes/QuizGame.tsx
+++ b/src/components/GameTypes/QuizGame.tsx
@@ -4,14 +4,26 @@ import { useGameResult } from '../../hooks/useGameResult';
 interface QuizGameProps {
   campaignId: string;
   config: any;
+  design?: any;
 }
 
-const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
+const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {}, design = {} }) => {
   const questions = config.questions || [];
   const { checkWinningCondition, saveResult } = useGameResult(campaignId, config);
   const [current, setCurrent] = useState(0);
   const [answers, setAnswers] = useState<number[]>([]);
   const [completed, setCompleted] = useState(false);
+  const [score, setScore] = useState(0);
+  const [started, setStarted] = useState(!config.introScreen);
+
+  const colors = design.customColors || { primary: '#841b60', text: '#ffffff' };
+  const textStyles = design.textStyles || {};
+  const containerStyles = {
+    backgroundColor: design.blockColor || '#ffffff',
+    border: `1px solid ${design.borderColor || '#e5e7eb'}`,
+    borderRadius: design.borderRadius || '0.5rem',
+    padding: '1rem'
+  };
 
   const handleAnswer = async (index: number) => {
     const newAnswers = [...answers, index];
@@ -20,17 +32,18 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
       setCurrent(current + 1);
     } else {
       const finalAnswers = newAnswers;
-      const score = questions.reduce((acc: number, q: any, i: number) => {
+      const finalScore = questions.reduce((acc: number, q: any, i: number) => {
         const option = q.options?.[finalAnswers[i]];
         return acc + (option && option.isCorrect ? 1 : 0);
       }, 0);
+      setScore(finalScore);
       const isWinner = await checkWinningCondition();
       await saveResult({
         campaignId,
         userId: 'anonymous',
         gameType: 'quiz',
         result: finalAnswers,
-        score,
+        score: finalScore,
         isWinner,
       });
       setAnswers(finalAnswers);
@@ -38,8 +51,42 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
     }
   };
 
+  if (!started) {
+    return (
+      <div className="text-center space-y-4" style={containerStyles}>
+        <h3 className="text-lg font-medium" style={textStyles.title}>
+          {config.introScreen?.title || 'Bienvenue au quiz'}
+        </h3>
+        {config.introScreen?.description && (
+          <p style={textStyles.description}>{config.introScreen.description}</p>
+        )}
+        <button
+          onClick={() => setStarted(true)}
+          className="px-4 py-2 rounded-lg"
+          style={{
+            backgroundColor: design.buttonColor || colors.primary,
+            color: design.buttonTextColor || colors.text,
+            borderRadius: design.borderRadius,
+            ...textStyles.button
+          }}
+        >
+          {config.introScreen?.buttonText || 'Commencer'}
+        </button>
+      </div>
+    );
+  }
+
   if (completed) {
-    return <div className="text-center p-4">Merci d\'avoir participé !</div>;
+    return (
+      <div className="text-center space-y-2" style={containerStyles}>
+        <h3 className="text-lg font-semibold" style={textStyles.title}>
+          {config.endMessage || 'Félicitations !'}
+        </h3>
+        <p style={textStyles.description}>
+          Vous avez obtenu {score} / {questions.length} points.
+        </p>
+      </div>
+    );
   }
 
   const question = questions[current];
@@ -48,13 +95,22 @@ const QuizGame: React.FC<QuizGameProps> = ({ campaignId, config = {} }) => {
   }
 
   return (
-    <div className="space-y-4">
-      <h3 className="text-lg font-medium">{question.text}</h3>
+    <div className="space-y-4" style={containerStyles}>
+      <p className="text-sm" style={textStyles.label}>
+        Question {current + 1} sur {questions.length}
+      </p>
+      <h3 className="text-lg font-medium" style={textStyles.title}>{question.text}</h3>
       {question.options?.map((option: any, idx: number) => (
         <button
           key={option.id}
           onClick={() => handleAnswer(idx)}
-          className="block w-full px-4 py-2 bg-[#841b60] text-white rounded-lg hover:bg-[#6d164f]"
+          className="block w-full px-4 py-2 rounded-lg transition-colors"
+          style={{
+            backgroundColor: design.buttonColor || colors.primary,
+            color: design.buttonTextColor || colors.text,
+            borderRadius: design.borderRadius,
+            ...textStyles.button
+          }}
         >
           {option.text}
         </button>

--- a/src/components/ModernEditor/ModernDesignTab.tsx
+++ b/src/components/ModernEditor/ModernDesignTab.tsx
@@ -16,6 +16,17 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
   const customTexts = design.customTexts || [];
   const customImages = design.customImages || [];
 
+  const getRadiusValue = () => {
+    const raw = design.borderRadius || '8px';
+    if (typeof raw === 'number') return raw;
+    if (raw.includes('rem')) {
+      const rem = parseFloat(raw);
+      return isNaN(rem) ? 8 : rem * 16;
+    }
+    const num = parseInt(raw, 10);
+    return isNaN(num) ? 8 : num;
+  };
+
   const handleBackgroundImageChange = (imageUrl: string) => {
     setCampaign({
       ...campaign,
@@ -200,11 +211,106 @@ const ModernDesignTab: React.FC<ModernDesignTabProps> = ({
           />
         </div>
 
+      <div>
+        <ImageUpload
+          value={design.mobileBackgroundImage || ''}
+          onChange={handleMobileBackgroundImageChange}
+          label="Image de fond (Mobile)"
+        />
+      </div>
+      </div>
+
+      {/* Game Style Settings */}
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-gray-900">Style du jeu</h3>
+
         <div>
-          <ImageUpload
-            value={design.mobileBackgroundImage || ''}
-            onChange={handleMobileBackgroundImageChange}
-            label="Image de fond (Mobile)"
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Couleur du cadre
+          </label>
+          <input
+            type="color"
+            value={design.blockColor || '#ffffff'}
+            onChange={(e) =>
+              setCampaign({
+                ...campaign,
+                design: { ...design, blockColor: e.target.value }
+              })
+            }
+            className="w-full h-10 rounded-lg border border-gray-300"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Couleur de bordure
+          </label>
+          <input
+            type="color"
+            value={design.borderColor || '#e5e7eb'}
+            onChange={(e) =>
+              setCampaign({
+                ...campaign,
+                design: { ...design, borderColor: e.target.value }
+              })
+            }
+            className="w-full h-10 rounded-lg border border-gray-300"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Rayon de bordure
+          </label>
+          <input
+            type="range"
+            min="0"
+            max="32"
+            value={getRadiusValue()}
+            onChange={(e) =>
+              setCampaign({
+                ...campaign,
+                design: { ...design, borderRadius: `${e.target.value}px` }
+              })
+            }
+            className="w-full"
+          />
+          <div className="text-xs text-gray-500 text-center">
+            {getRadiusValue()}px
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Couleur des boutons
+          </label>
+          <input
+            type="color"
+            value={design.buttonColor || design.primaryColor || '#841b60'}
+            onChange={(e) =>
+              setCampaign({
+                ...campaign,
+                design: { ...design, buttonColor: e.target.value }
+              })
+            }
+            className="w-full h-10 rounded-lg border border-gray-300"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Couleur du texte des boutons
+          </label>
+          <input
+            type="color"
+            value={design.buttonTextColor || '#ffffff'}
+            onChange={(e) =>
+              setCampaign({
+                ...campaign,
+                design: { ...design, buttonTextColor: e.target.value }
+              })
+            }
+            className="w-full h-10 rounded-lg border border-gray-300"
           />
         </div>
       </div>

--- a/src/components/funnels/FunnelStandard.tsx
+++ b/src/components/funnels/FunnelStandard.tsx
@@ -61,7 +61,11 @@ const FunnelStandard: React.FC<GameFunnelProps> = ({ campaign }) => {
     switch (campaign.type) {
       case 'quiz':
         return (
-          <QuizGame campaignId={campaign.id} config={campaign.gameConfig.quiz} />
+          <QuizGame
+            campaignId={campaign.id}
+            config={campaign.gameConfig.quiz}
+            design={campaign.design}
+          />
         );
       case 'memory':
         return <Memory config={campaign.gameConfig.memory} onConfigChange={() => {}} />;

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -119,6 +119,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
           <QuizGame
             campaignId={campaign.id}
             config={campaign.gameConfig?.quiz || {}}
+            design={campaign.design}
           />
         );
       case 'dice':


### PR DESCRIPTION
## Summary
- update quiz preview to use `QuizGame`
- add intro screen and progress tracking in `QuizGame`
- show final score with campaign styling
- allow customizing quiz frame, border, and button colors
- expose quiz styling options in the design tab

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c959354f0832a865ae13c4995adf9