### PR TITLE
Add OpenAI quiz generation API

### DIFF
--- a/src/components/ModernWizard/ModernWizard.tsx
+++ b/src/components/ModernWizard/ModernWizard.tsx
@@ -17,6 +17,7 @@ export interface WizardData {
   websiteUrl?: string;
   productName?: string;
   generatedCampaign?: any;
+  generatedQuiz?: any;
   customizations?: any;
 }
 

--- a/src/components/ModernWizard/steps/GenerationStep.tsx
+++ b/src/components/ModernWizard/steps/GenerationStep.tsx
@@ -26,29 +26,28 @@ const GenerationStep: React.FC<GenerationStepProps> = ({
 
   const handleGenerate = async () => {
     setIsGenerating(true);
-    
-    // Simulate AI generation process
-    await new Promise(resolve => setTimeout(resolve, 3000));
-    
-    // Update wizard data with generated campaign
-    const generatedCampaign = {
-      id: Date.now().toString(),
-      name: wizardData.productName || 'Ma Campagne',
-      type: wizardData.selectedGame,
-      status: 'draft',
-      design: {
-        primaryColor: '#951b6d',
-        background: '#f8fafc'
-      }
-    };
-    
-    updateWizardData({ generatedCampaign });
-    setIsGenerating(false);
-    
-    // Automatically go to next step (Preview) after generation is complete
-    setTimeout(() => {
-      nextStep();
-    }, 500);
+
+    try {
+      const response = await fetch('/api/quiz', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          logoUrl: wizardData.logo,
+          desktopVisualUrl: wizardData.desktopVisual,
+          mobileVisualUrl: wizardData.mobileVisual,
+          websiteUrl: wizardData.websiteUrl,
+          productName: wizardData.productName
+        })
+      });
+
+      const data = await response.json();
+      updateWizardData({ generatedQuiz: data });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsGenerating(false);
+      setTimeout(() => nextStep(), 500);
+    }
   };
 
   return (

--- a/src/components/ModernWizard/steps/PreviewStep.tsx
+++ b/src/components/ModernWizard/steps/PreviewStep.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { WizardData } from '../ModernWizard';
-import { Eye, Monitor, Smartphone, Tablet } from 'lucide-react';
+import { Eye, Monitor, Smartphone, Tablet, Loader } from 'lucide-react';
+import QuizPreview from '../../GameTypes/QuizPreview';
 interface PreviewStepProps {
   wizardData: WizardData;
   updateWizardData: (data: Partial<WizardData>) => void;
@@ -12,7 +13,27 @@ const PreviewStep: React.FC<PreviewStepProps> = ({
   nextStep,
   prevStep
 }) => {
+  const buildQuizConfig = () => {
+    if (!wizardData.generatedQuiz) return { questions: [] };
+    const qs = wizardData.generatedQuiz.questions || [];
+    return {
+      questions: qs.map((q: any, qi: number) => ({
+        id: qi,
+        text: q.question,
+        options: q.choices.map((c: string, ci: number) => ({
+          id: ci,
+          text: c,
+          isCorrect: c === q.answer
+        })),
+        feedback: { correct: wizardData.generatedQuiz.successText, incorrect: wizardData.generatedQuiz.errorText }
+      }))
+    };
+  };
+
   const [selectedDevice, setSelectedDevice] = React.useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+
+  const visual = selectedDevice === 'mobile' ? (wizardData.mobileVisual || wizardData.desktopVisual) : wizardData.desktopVisual;
+
   return <div className="space-y-6">
       {/* Main Content Card */}
       <div className="bg-white/70 backdrop-blur-sm rounded-2xl p-8 shadow-sm border border-gray-100/50">
@@ -61,38 +82,17 @@ const PreviewStep: React.FC<PreviewStepProps> = ({
             <h3 className="font-semibold text-[#141e29]">Aperçu {selectedDevice}</h3>
           </div>
 
-          <div className="bg-gray-50 rounded-xl p-8 min-h-96 flex items-center justify-center">
-            <div className="text-center space-y-4">
-              {selectedDevice === 'desktop' && <div className="w-96 h-64 bg-white rounded-xl shadow-sm border border-gray-200 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="w-16 h-16 bg-[#951b6d]/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <Monitor className="w-8 h-8 text-[#951b6d]" />
-                    </div>
-                    <h4 className="font-semibold text-[#141e29] mb-2">{wizardData.productName || 'Ma Campagne'}</h4>
-                    <p className="text-sm text-gray-600">Aperçu desktop de votre campagne {wizardData.selectedGame}</p>
-                  </div>
-                </div>}
-              
-              {selectedDevice === 'tablet' && <div className="w-80 h-60 bg-white rounded-xl shadow-sm border border-gray-200 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="w-16 h-16 bg-[#951b6d]/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <Tablet className="w-8 h-8 text-[#951b6d]" />
-                    </div>
-                    <h4 className="font-semibold text-[#141e29] mb-2">{wizardData.productName || 'Ma Campagne'}</h4>
-                    <p className="text-sm text-gray-600">Aperçu tablet de votre campagne {wizardData.selectedGame}</p>
-                  </div>
-                </div>}
-              
-              {selectedDevice === 'mobile' && <div className="w-64 h-96 bg-white rounded-xl shadow-sm border border-gray-200 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="w-16 h-16 bg-[#951b6d]/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                      <Smartphone className="w-8 h-8 text-[#951b6d]" />
-                    </div>
-                    <h4 className="font-semibold text-[#141e29] mb-2">{wizardData.productName || 'Ma Campagne'}</h4>
-                    <p className="text-sm text-gray-600">Aperçu mobile de votre campagne {wizardData.selectedGame}</p>
-                  </div>
-                </div>}
-            </div>
+          <div className="bg-gray-50 rounded-xl p-8 min-h-96 flex items-center justify-center" style={{ backgroundImage: visual ? `url(${visual})` : undefined, backgroundSize: 'cover', backgroundPosition: 'center' }}>
+            {wizardData.generatedQuiz ? (
+              <QuizPreview config={buildQuizConfig()} design={{}} />
+            ) : (
+              <div className="text-center space-y-4">
+                <div className="w-16 h-16 bg-[#951b6d]/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <Loader className="w-8 h-8 text-[#951b6d] animate-spin" />
+                </div>
+                <p className="text-gray-600">Chargement de l'aperçu...</p>
+              </div>
+            )}
           </div>
         </div>
 
@@ -108,7 +108,10 @@ const PreviewStep: React.FC<PreviewStepProps> = ({
             Publier la campagne
           </button>
         </div>
+        </div>
       </div>
-    </div>;
+    </div>
+  );
 };
+
 export default PreviewStep;

--- a/supabase/functions/quiz/index.ts
+++ b/supabase/functions/quiz/index.ts
@@ -1,0 +1,39 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import OpenAI from 'npm:openai';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { logoUrl, desktopVisualUrl, mobileVisualUrl, websiteUrl, productName } = await req.json();
+
+    const prompt = `G\u00e9n\u00e8re un jeu concours de type "Quiz Interactif" 100% pr\u00eat \u00e0 l'emploi, pour la marque suivante:\n- Nom du produit: ${productName}\n- Logo: ${logoUrl}\n- Visuel desktop: ${desktopVisualUrl}\n- Visuel mobile: ${mobileVisualUrl || '(utilise le desktop si vide)'}\n- URL du site: ${websiteUrl}\n\nContraintes:\n- G\u00e9n\u00e8re 5 questions quiz pertinentes (avec r\u00e9ponses) en lien avec la marque/produit (utilise le site si fourni)\n- G\u00e9n\u00e8re wording d'intro, description courte, CTA, textes erreur/succ\u00e8s, tout en gardant un ton marketing/conversion\n- Format JSON structuré :\n{\n  "intro": "",\n  "cta": "",\n  "questions": [\n    { "question": "", "choices": ["", "", ""], "answer": "" }\n  ],\n  "errorText": "",\n  "successText": ""\n}\n- N'invente pas de visuel ou d'image, utilise uniquement ce qui a \u00e9t\u00e9 upload\u00e9\n- Ne cr\u00e9e jamais de champ de texte libre pour l'utilisateur final, ni de prompt \u00e0 compl\u00e9ter.`;
+
+    const openai = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY') });
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.7
+    });
+
+    const content = completion.choices[0].message?.content || '{}';
+    const data = JSON.parse(content);
+
+    return new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- implement new Supabase function `quiz` to generate quiz text via OpenAI
- store generated quiz data in `WizardData`
- call `/api/quiz` from the wizard generation step
- show generated quiz in preview step with `QuizPreview`

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eaf695c8c832a84ccdfc77497a6a0