### PR TITLE
Fix npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "build:dev": "vite build --mode development",
-    "test": "tsx --test test/*.test.ts"
+    "test": "npx tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",


### PR DESCRIPTION
## Summary
- use `npx tsx` in the npm test script so the suite can run even if `tsx` is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb4dd5c80832a971d0a6ca3716639