### PR TITLE
Add configurable quiz endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ VITE_RESEND_API_KEY=
 # OpenAI API key for quiz generation
 OPENAI_API_KEY=your_openai_key_here
 
+# Endpoint for the quiz generation function
+VITE_QUIZ_ENDPOINT=
+
 # Brandfetch API key
 VITE_BRANDFETCH_KEY=your_key_here
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ quiz content and therefore requires an `OPENAI_API_KEY` in your environment.
    OPENAI_API_KEY=your_key_here
    ```
 
-With Supabase running locally, you can trigger the function by sending a POST
-request to `/api/quiz`:
+With Supabase running locally, the function is available at
+`http://localhost:54321/functions/v1/quiz`. In production it uses your Supabase
+URL, e.g. `https://<project>.supabase.co/functions/v1/quiz`.
+
+Set this URL via the `VITE_QUIZ_ENDPOINT` variable in your `.env.local` file so
+the app knows where to send quiz generation requests.
+
+You can trigger the function manually by sending a POST request:
 
 ```bash
 curl -X POST \
@@ -58,8 +64,8 @@ curl -X POST \
      http://localhost:54321/functions/v1/quiz
 ```
 
-When deployed, the same endpoint is available at `/api/quiz` on your Supabase
-project.
+When deployed, use the corresponding URL for your Supabase project, for example
+`https://<project>.supabase.co/functions/v1/quiz`.
 
 ## Build
 

--- a/src/components/ModernWizard/steps/GenerationStep.tsx
+++ b/src/components/ModernWizard/steps/GenerationStep.tsx
@@ -16,6 +16,7 @@ const GenerationStep: React.FC<GenerationStepProps> = ({
   prevStep
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
+  const quizEndpoint = import.meta.env.VITE_QUIZ_ENDPOINT || '/api/quiz';
 
   useEffect(() => {
     // Auto-start generation when step loads
@@ -28,7 +29,7 @@ const GenerationStep: React.FC<GenerationStepProps> = ({
     setIsGenerating(true);
 
     try {
-      const response = await fetch('/api/quiz', {
+      const response = await fetch(quizEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -39,6 +40,11 @@ const GenerationStep: React.FC<GenerationStepProps> = ({
           productName: wizardData.productName
         })
       });
+
+      if (!response.ok) {
+        console.error(`Quiz generation failed: ${response.status}`);
+        return;
+      }
 
       const data = await response.json();
       updateWizardData({ generatedQuiz: data });


### PR DESCRIPTION
## Summary
- add `VITE_QUIZ_ENDPOINT` example to env file
- use `import.meta.env.VITE_QUIZ_ENDPOINT` in generation step
- log an error when quiz generation fails
- document quiz endpoint variable and example URLs in README

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ecd9ddfe0832a92a1a99d98f4992b