### PR TITLE
Fix advanced editor button route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import AdminTeam from './pages/AdminTeam';
 import AdminAlerts from './pages/AdminAlerts';
 import AdminReports from './pages/AdminReports';
 import AdminSettings from './pages/AdminSettings';
+import ModernCampaignEditor from './pages/ModernCampaignEditor';
 import AdminLayout from './components/Admin/AdminLayout';
 import Layout from './components/Layout/Layout';
 
@@ -77,6 +78,7 @@ function App() {
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/campaigns" element={<Campaigns />} />
               <Route path="/campaign/:id" element={<CampaignEditor />} />
+              <Route path="/modern-campaign/:id" element={<ModernCampaignEditor />} />
               <Route path="/quick-campaign" element={<QuickCampaign />} />
               <Route path="/modern-wizard" element={<ModernWizardPage />} />
               <Route path="/gamification" element={<Gamification />} />

--- a/src/components/QuickCampaign/Step3VisualStyle.tsx
+++ b/src/components/QuickCampaign/Step3VisualStyle.tsx
@@ -159,7 +159,7 @@ const Step3VisualStyle: React.FC = () => {
       const result = await saveCampaign(campaignData);
       if (result) {
         reset();
-        navigate(`/campaign/${result.id}`);
+        navigate(`/modern-campaign/${result.id}`);
       }
     } catch (error) {
       console.error('Erreur lors de la création:', error);
@@ -204,7 +204,7 @@ const Step3VisualStyle: React.FC = () => {
                                border border-gray-200 hover:bg-gray-100 transition-all
                                flex items-center justify-center space-x-3 disabled:opacity-50">
                     <Settings className="w-5 h-5" />
-                    <span>Réglages avancés</span>
+                    <span>Éditeur avancé</span>
                   </button>
                 </div>
               </>}


### PR DESCRIPTION
## Summary
- route `/modern-campaign/:id` directly to `ModernCampaignEditor`

## Testing
- `npm test` *(fails: tries to install `tsx` interactively)*


------
https://chatgpt.com/codex/tasks/task_e_684f5890ac84832aac9663ef78e22f25