### PR TITLE
Fix advanced editor link

### DIFF
--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -188,7 +188,7 @@ const Campaigns: React.FC = () => {
               Création rapide
             </Link>
             <Link
-              to="/campaign/new"
+              to="/modern-campaign/new"
               className="inline-flex items-center px-6 py-2.5 bg-[#841b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />


### PR DESCRIPTION
## Summary
- route advanced editor button to modern campaign creation path

## Testing
- `npm test --silent` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_68505e980bb4832a84fe634e4345219e