### PR TITLE
Fix background image persistence in quick campaign

### DIFF
--- a/src/components/QuickCampaign/Step2BasicSettings.tsx
+++ b/src/components/QuickCampaign/Step2BasicSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft, ArrowRight, Calendar, Upload } from 'lucide-react';
 import { useQuickCampaignStore } from '../../stores/quickCampaignStore';
@@ -19,19 +19,17 @@ const Step2BasicSettings: React.FC = () => {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Nettoyage de l'URL de l'image pour éviter les leaks mémoire
-  useEffect(() => {
-    return () => {
-      if (backgroundImageUrl) {
-        URL.revokeObjectURL(backgroundImageUrl);
-      }
-    };
-  }, [backgroundImageUrl]);
 
   const handleFileUpload = (files: FileList | null) => {
     if (files && files[0]) {
       const file = files[0];
       setBackgroundImage(file);
+
+      // Nettoie l'ancienne URL si une nouvelle image est sélectionnée
+      if (backgroundImageUrl) {
+        URL.revokeObjectURL(backgroundImageUrl);
+      }
+
       const url = URL.createObjectURL(file);
       setBackgroundImageUrl(url);
     }

--- a/src/stores/quickCampaignStore.ts
+++ b/src/stores/quickCampaignStore.ts
@@ -177,10 +177,15 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
     return baseConfig;
   },
 
-  reset: () => set({
-    currentStep: 1,
-    campaignName: 'Ma Nouvelle Campagne',
-    selectedGameType: null,
+  reset: () => {
+    const url = get().backgroundImageUrl;
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+    set({
+      currentStep: 1,
+      campaignName: 'Ma Nouvelle Campagne',
+      selectedGameType: null,
     launchDate: '',
     marketingGoal: '',
     logoFile: null,
@@ -207,4 +212,5 @@ export const useQuickCampaignStore = create<QuickCampaignState>((set, get) => ({
       slotBackgroundColor: '#ffffff'
     }
   })
+  }
 }));


### PR DESCRIPTION
## Summary
- keep background image URL across wizard steps
- revoke background image URL on reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850771924e4832aba6bbf7870217c60