### PR TITLE
Remove unused imports for clean build

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import QuickCampaign from './pages/QuickCampaign';
 import CampaignPreview from './pages/CampaignPreview';

--- a/src/components/common/PreviewWindowButton.tsx
+++ b/src/components/common/PreviewWindowButton.tsx
@@ -1,7 +1,7 @@
 
-import React from 'react';
 import { ExternalLink, Eye } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import type { FC } from 'react';
 
 interface PreviewWindowButtonProps {
   campaign: any;
@@ -12,9 +12,7 @@ interface PreviewWindowButtonProps {
   size?: 'sm' | 'md' | 'lg';
 }
 
-const PreviewWindowButton: React.FC<PreviewWindowButtonProps> = ({
-  campaign,
-  title,
+const PreviewWindowButton: FC<PreviewWindowButtonProps> = ({
   children,
   className = '',
   variant = 'default',

--- a/src/pages/CampaignPreview.tsx
+++ b/src/pages/CampaignPreview.tsx
@@ -1,13 +1,13 @@
 
-import React, { useEffect, useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import type { FC } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { X, ArrowLeft } from 'lucide-react';
 import { useQuickCampaignStore } from '../stores/quickCampaignStore';
 import PreviewContent from '../components/QuickCampaign/Preview/PreviewContent';
 import DeviceSelector from '../components/QuickCampaign/Preview/DeviceSelector';
 
-const CampaignPreview: React.FC = () => {
-  const [searchParams] = useSearchParams();
+const CampaignPreview: FC = () => {
   const navigate = useNavigate();
   const [selectedDevice, setSelectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
   


### PR DESCRIPTION
## Summary
- clean unused imports from App
- remove unused props in PreviewWindowButton and update types
- tidy CampaignPreview imports and props

## Testing
- `npm run build`
- `npm test`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_6851ed90e6b4832ab4d343bee186ea62