### PR TITLE
Add wizard page scaffolding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Data from './pages/Data';
 import Social from './pages/Social';
 import Studies from './pages/Studies';
 import ModernWizardPage from './pages/ModernWizardPage';
+import WizardPage from './pages/WizardPage';
 import Admin from './pages/Admin';
 import AdminClients from './pages/AdminClients';
 import AdminClientDetail from './pages/AdminClientDetail';
@@ -81,6 +82,7 @@ function App() {
               <Route path="/modern-campaign/:id" element={<ModernEditorPage />} />
               <Route path="/quick-campaign" element={<QuickCampaign />} />
               <Route path="/modern-wizard" element={<ModernWizardPage />} />
+              <Route path="/wizard" element={<WizardPage />} />
               <Route path="/gamification" element={<Gamification />} />
               <Route path="/newsletter" element={<Newsletter />} />
               <Route path="/statistics" element={<Statistics />} />

--- a/src/components/Wizard/BrandSettingsForm.tsx
+++ b/src/components/Wizard/BrandSettingsForm.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+export interface Segment {
+  color: string;
+  prize: string;
+}
+
+export interface BrandSettings {
+  brandName: string;
+  logo?: string;
+  gameTitle: string;
+  segmentCount: number;
+  segments: Segment[];
+  desktopBg?: string;
+  mobileBg?: string;
+  style: string;
+  brandUrl: string;
+}
+
+interface Props {
+  settings: BrandSettings;
+  updateSettings: (data: Partial<BrandSettings>) => void;
+}
+
+const BrandSettingsForm: React.FC<Props> = ({ settings, updateSettings }) => {
+  const handleSegmentCountChange = (count: number) => {
+    const segments = [...settings.segments];
+    if (count > segments.length) {
+      for (let i = segments.length; i < count; i++) {
+        segments.push({ color: '#841b60', prize: '' });
+      }
+    } else {
+      segments.splice(count);
+    }
+    updateSettings({ segmentCount: count, segments });
+  };
+
+  const handleSegmentChange = (index: number, key: keyof Segment, value: string) => {
+    const segments = settings.segments.map((seg, i) =>
+      i === index ? { ...seg, [key]: value } : seg
+    );
+    updateSettings({ segments });
+  };
+
+  const handleFile = (key: 'logo' | 'desktopBg' | 'mobileBg', files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => updateSettings({ [key]: e.target?.result as string } as Partial<BrandSettings>);
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold mb-4">Brand settings</h2>
+      <div>
+        <label className="block text-sm font-medium mb-1">Brand name</label>
+        <input
+          type="text"
+          value={settings.brandName}
+          onChange={e => updateSettings({ brandName: e.target.value })}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Logo</label>
+        <input type="file" accept="image/*" onChange={e => handleFile('logo', e.target.files)} />
+        {settings.logo && <img src={settings.logo} alt="logo" className="mt-2 h-16 object-contain" />}
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Game title</label>
+        <input
+          type="text"
+          value={settings.gameTitle}
+          onChange={e => updateSettings({ gameTitle: e.target.value })}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Number of segments: {settings.segmentCount}</label>
+        <input
+          type="range"
+          min={1}
+          max={12}
+          value={settings.segmentCount}
+          onChange={e => handleSegmentCountChange(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+      {settings.segments.map((seg, index) => (
+        <div key={index} className="flex items-center space-x-3">
+          <input
+            type="color"
+            value={seg.color}
+            onChange={e => handleSegmentChange(index, 'color', e.target.value)}
+            className="w-12 h-10 border rounded"
+          />
+          <input
+            type="text"
+            value={seg.prize}
+            placeholder={`Prize ${index + 1}`}
+            onChange={e => handleSegmentChange(index, 'prize', e.target.value)}
+            className="border p-2 rounded flex-1"
+          />
+        </div>
+      ))}
+      <div>
+        <label className="block text-sm font-medium mb-1">Desktop background</label>
+        <input type="file" accept="image/*" onChange={e => handleFile('desktopBg', e.target.files)} />
+        {settings.desktopBg && <img src={settings.desktopBg} alt="desktop background" className="mt-2 h-20 object-cover" />}
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Mobile background</label>
+        <input type="file" accept="image/*" onChange={e => handleFile('mobileBg', e.target.files)} />
+        {settings.mobileBg && <img src={settings.mobileBg} alt="mobile background" className="mt-2 h-20 object-cover" />}
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Style</label>
+        <select
+          value={settings.style}
+          onChange={e => updateSettings({ style: e.target.value })}
+          className="border p-2 rounded w-full"
+        >
+          <option value="Premium">Premium</option>
+          <option value="Fun">Fun</option>
+          <option value="Minimal">Minimal</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Brand URL (optional)</label>
+        <input
+          type="text"
+          value={settings.brandUrl}
+          onChange={e => updateSettings({ brandUrl: e.target.value })}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default BrandSettingsForm;

--- a/src/components/Wizard/WheelPreview.tsx
+++ b/src/components/Wizard/WheelPreview.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { BrandSettings } from './BrandSettingsForm';
+
+interface Props {
+  settings: BrandSettings;
+}
+
+const WheelPreview: React.FC<Props> = ({ settings }) => {
+  return (
+    <div className="border rounded-xl p-6 bg-white/70 backdrop-blur-sm shadow-sm h-full flex flex-col items-center justify-center">
+      <h2 className="text-xl font-semibold mb-4">Wheel of Fortune Preview</h2>
+      <div className="w-48 h-48 bg-gray-100 flex items-center justify-center rounded-full">
+        {/* Placeholder for wheel rendering */}
+        <span className="text-gray-500 text-sm">{settings.gameTitle || 'Preview'}</span>
+      </div>
+    </div>
+  );
+};
+
+export default WheelPreview;

--- a/src/pages/WizardPage.tsx
+++ b/src/pages/WizardPage.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import BrandSettingsForm, { BrandSettings, Segment } from '../components/Wizard/BrandSettingsForm';
+import WheelPreview from '../components/Wizard/WheelPreview';
+
+const defaultSegments: Segment[] = Array.from({ length: 6 }).map(() => ({
+  color: '#841b60',
+  prize: ''
+}));
+
+const WizardPage: React.FC = () => {
+  const [settings, setSettings] = useState<BrandSettings>({
+    brandName: '',
+    logo: undefined,
+    gameTitle: '',
+    segmentCount: 6,
+    segments: defaultSegments,
+    desktopBg: undefined,
+    mobileBg: undefined,
+    style: 'Premium',
+    brandUrl: ''
+  });
+
+  const updateSettings = (data: Partial<BrandSettings>) => {
+    setSettings(prev => ({ ...prev, ...data }));
+  };
+
+  return (
+    <div className="p-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white/70 backdrop-blur-sm p-6 rounded-xl shadow-sm">
+          <BrandSettingsForm settings={settings} updateSettings={updateSettings} />
+        </div>
+        <WheelPreview settings={settings} />
+      </div>
+    </div>
+  );
+};
+
+export default WizardPage;


### PR DESCRIPTION
## Summary
- add new `WizardPage` route and component
- implement brand settings form scaffolding
- add wheel preview placeholder

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_685457bc37b8832aac2c0c65d9760c41