### PR TITLE
Fix Quick Campaign live preview cropping

### DIFF
--- a/src/components/QuickCampaign/Preview/DeviceFrame.tsx
+++ b/src/components/QuickCampaign/Preview/DeviceFrame.tsx
@@ -41,10 +41,10 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({ device, children }) => {
           ? "bg-gray-900 rounded-[3rem] p-2 shadow-2xl flex items-center justify-center"
           : "bg-gray-800 rounded-3xl p-6 shadow-2xl flex items-center justify-center"}
         style={{
-          // Calcul dynamique : 80% du parent max, sinon dim. réelle, ratio respecté
+          height: '100%',
+          width: 'auto',
           maxWidth: 'min(80vw, 100%)',
           maxHeight: 'min(80vh, 100%)',
-          width: device === 'mobile' ? 375 : 768,
           aspectRatio: aspect.toString(),
         }}
       >

--- a/src/components/QuickCampaign/Step3/PreviewPanel.tsx
+++ b/src/components/QuickCampaign/Step3/PreviewPanel.tsx
@@ -62,9 +62,11 @@ const PreviewPanel: React.FC = () => {
         
         <div className="p-6">
           {/* Container adaptatif selon l'appareil */}
-          <div className={`w-full bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl overflow-hidden border border-gray-200 relative ${
-            selectedDevice === 'desktop' ? 'h-[500px]' : 'h-[600px]'
-          }`}>
+          <div
+            className={`w-full bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl border border-gray-200 relative p-4 overflow-visible ${
+              selectedDevice === 'desktop' ? 'h-[500px]' : 'min-h-[620px]'
+            }`}
+          >
             {/* Barre de navigation pour desktop */}
             {selectedDevice === 'desktop' && (
               <div className="bg-white border-b border-gray-200 px-4 py-2 flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- adjust device frame to always use full height and maintain aspect ratio
- allow extra padding for preview container so mobile and tablet frames are fully visible

## Testing
- `npm test` *(fails: tsx package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685584d42ebc832a86b8c0b4ab70cbc9