### PR TITLE
Add API key check to quiz function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ quiz content and therefore requires an `OPENAI_API_KEY` in your environment.
    OPENAI_API_KEY=your_key_here
    ```
 
+If the key is not defined, the function returns a JSON error response with a 500
+status code:
+
+```json
+{ "error": "Missing OPENAI_API_KEY" }
+```
+
 With Supabase running locally, the function is available at
 `http://localhost:54321/functions/v1/quiz`. In production it uses your Supabase
 URL, e.g. `https://<project>.supabase.co/functions/v1/quiz`.

--- a/supabase/functions/quiz/index.ts
+++ b/supabase/functions/quiz/index.ts
@@ -12,6 +12,15 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
+  if (!openAIApiKey) {
+    return new Response(
+      JSON.stringify({ error: 'Missing OPENAI_API_KEY' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
+  }
   try {
     const body = await req.json();
 


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` inside the quiz function
- document error in quiz README section

## Testing
- `npm test` *(fails: Need to install tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68558f799f34832a8e2b9162aed6cffc