### PR TITLE
Add expert mode and pointer customization

### DIFF
--- a/src/components/GameTypes/WheelComponents/WheelPointer.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPointer.tsx
@@ -6,13 +6,15 @@ interface WheelPointerProps {
   shouldCropWheel: boolean;
   gamePosition: 'top' | 'center' | 'bottom' | 'left' | 'right';
   pointerSize: number;
+  pointerImageUrl?: string | null;
 }
 
 const WheelPointer: React.FC<WheelPointerProps> = ({
   canvasSize,
   shouldCropWheel,
   gamePosition,
-  pointerSize
+  pointerSize,
+  pointerImageUrl
 }) => {
   // Calcul de la position horizontale du pointeur
   const getPointerLeft = () => {
@@ -44,21 +46,25 @@ const WheelPointer: React.FC<WheelPointerProps> = ({
         alignItems: 'flex-start',
       }}
     >
-      <svg width={pointerSize} height={pointerSize * 1.6}>
-        <defs>
-          <linearGradient id="pointerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#FFD700" />
-            <stop offset="50%" stopColor="#FFA500" />
-            <stop offset="100%" stopColor="#B8860B" />
-          </linearGradient>
-        </defs>
-        <polygon
-          points={`${pointerSize/2},${pointerSize*1.6} ${pointerSize*0.85},${pointerSize*0.4} ${pointerSize*0.15},${pointerSize*0.4}`}
-          fill="url(#pointerGradient)"
-          stroke="#8B4513"
-          strokeWidth="2"
-        />
-      </svg>
+      {pointerImageUrl ? (
+        <img src={pointerImageUrl} alt="Pointer" style={{ width: pointerSize, height: pointerSize * 1.6 }} />
+      ) : (
+        <svg width={pointerSize} height={pointerSize * 1.6}>
+          <defs>
+            <linearGradient id="pointerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stopColor="#FFD700" />
+              <stop offset="50%" stopColor="#FFA500" />
+              <stop offset="100%" stopColor="#B8860B" />
+            </linearGradient>
+          </defs>
+          <polygon
+            points={`${pointerSize/2},${pointerSize*1.6} ${pointerSize*0.85},${pointerSize*0.4} ${pointerSize*0.15},${pointerSize*0.4}`}
+            fill="url(#pointerGradient)"
+            stroke="#8B4513"
+            strokeWidth="2"
+          />
+        </svg>
+      )}
     </div>
   );
 };

--- a/src/components/GameTypes/WheelComponents/WheelPreviewConfig.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewConfig.tsx
@@ -8,6 +8,7 @@ export const getWheelPreviewConfig = (campaign: any) => {
   const borderOutlineColor = campaign?.config?.roulette?.borderOutlineColor || '#FFD700';
 
   const customColors = campaign?.design?.customColors;
+  const pointerImage = campaign?.design?.pointerImage;
 
   const buttonConfig = campaign?.buttonConfig || {
     color: customColors?.primary || '#841b60',
@@ -29,6 +30,7 @@ export const getWheelPreviewConfig = (campaign: any) => {
     borderColor,
     borderOutlineColor,
     customColors,
+    pointerImage,
     buttonConfig
   };
 };

--- a/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
@@ -24,6 +24,7 @@ interface WheelPreviewContentProps {
   formValidated: boolean;
   showValidationMessage: boolean;
   onWheelClick: () => void;
+  pointerImage?: string | null;
 }
 
 const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
@@ -43,7 +44,8 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
   gamePosition,
   formValidated,
   showValidationMessage,
-  onWheelClick
+  onWheelClick,
+  pointerImage
 }) => {
   return (
     <div style={{ 
@@ -103,6 +105,7 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
           shouldCropWheel={shouldCropWheel}
           gamePosition={gamePosition}
           pointerSize={pointerSize}
+          pointerImageUrl={pointerImage}
         />
       </WheelInteractionHandler>
 

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -71,6 +71,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
     borderColor,
     borderOutlineColor,
     customColors,
+    pointerImage,
     buttonConfig
   } = getWheelPreviewConfig(campaign);
 
@@ -112,6 +113,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
           formValidated={formValidated}
           showValidationMessage={showValidationMessage}
           onWheelClick={handleWheelClick}
+          pointerImage={pointerImage}
         />
 
         <WheelButton

--- a/src/components/QuickCampaign/Step3/Step3Header.tsx
+++ b/src/components/QuickCampaign/Step3/Step3Header.tsx
@@ -9,7 +9,9 @@ const Step3Header: React.FC = () => {
     selectedGameType,
     setCurrentStep,
     generatePreviewCampaign,
-    campaignName
+    campaignName,
+    advancedMode,
+    setAdvancedMode
   } = useQuickCampaignStore();
 
   const mockCampaign = generatePreviewCampaign();
@@ -26,6 +28,15 @@ const Step3Header: React.FC = () => {
           </p>
         </div>
         <div className="flex items-center space-x-3">
+          <label className="flex items-center space-x-2 mr-4">
+            <input
+              type="checkbox"
+              checked={advancedMode}
+              onChange={(e) => setAdvancedMode(e.target.checked)}
+              className="rounded"
+            />
+            <span className="text-sm text-gray-700">Mode Expert</span>
+          </label>
           <button
             onClick={() => setCurrentStep(2)}
             className="flex items-center px-4 py-2 text-gray-600 bg-white rounded-xl border border-gray-200 hover:bg-gray-50 transition-colors shadow-sm"

--- a/src/components/QuickCampaign/Step3/WheelConfiguration.tsx
+++ b/src/components/QuickCampaign/Step3/WheelConfiguration.tsx
@@ -3,7 +3,26 @@ import React from 'react';
 import { useQuickCampaignStore } from '../../../stores/quickCampaignStore';
 
 const WheelConfiguration: React.FC = () => {
-  const { segmentCount, setSegmentCount } = useQuickCampaignStore();
+  const {
+    segmentCount,
+    setSegmentCount,
+    advancedMode,
+    pointerImageUrl,
+    setPointerImage,
+    setPointerImageUrl
+  } = useQuickCampaignStore();
+
+  const handlePointerUpload = (files: FileList | null) => {
+    if (files && files[0]) {
+      const file = files[0];
+      setPointerImage(file);
+      if (pointerImageUrl) {
+        URL.revokeObjectURL(pointerImageUrl);
+      }
+      const url = URL.createObjectURL(file);
+      setPointerImageUrl(url);
+    }
+  };
 
   return (
     <>
@@ -26,6 +45,23 @@ const WheelConfiguration: React.FC = () => {
             <span>12 segments</span>
           </div>
         </div>
+
+        {advancedMode && (
+          <div className="bg-gray-50 rounded-xl p-4">
+            <label className="block text-sm font-medium text-gray-700 mb-3">Pointeur personnalisé</label>
+            <div className="flex items-center space-x-3">
+              {pointerImageUrl && (
+                <img src={pointerImageUrl} alt="Aperçu pointeur" className="h-10" />
+              )}
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => handlePointerUpload(e.target.files)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/stores/quickCampaign/actions.ts
+++ b/src/stores/quickCampaign/actions.ts
@@ -19,6 +19,9 @@ export const createActions = (set: any, get: any) => ({
   setGamePosition: (position: 'top' | 'center' | 'bottom' | 'left' | 'right') => set({ gamePosition: position }),
   setCustomColors: (colors: { primary: string; secondary: string; accent: string; textColor?: string; buttonStyle?: string }) => set({ customColors: colors }),
   setJackpotColors: (colors: any) => set({ jackpotColors: colors }),
+  setAdvancedMode: (mode: boolean) => set({ advancedMode: mode }),
+  setPointerImage: (file: File | null) => set({ pointerImage: file }),
+  setPointerImageUrl: (url: string | null) => set({ pointerImageUrl: url }),
   setQuizQuestions: (questions: any[]) => set({ quizQuestions: questions }),
 
   reset: () => {

--- a/src/stores/quickCampaign/campaignGenerator.ts
+++ b/src/stores/quickCampaign/campaignGenerator.ts
@@ -11,6 +11,7 @@ export const generatePreviewCampaign = (state: QuickCampaignState) => {
       centerLogo: state.logoUrl || null,
       backgroundImage: state.backgroundImageUrl || null,
       mobileBackgroundImage: state.backgroundImageUrl || null,
+      pointerImage: state.pointerImageUrl || null,
       containerBackgroundColor: '#ffffff',
       borderColor: state.customColors.primary,
       borderRadius: '16px',

--- a/src/stores/quickCampaign/initialState.ts
+++ b/src/stores/quickCampaign/initialState.ts
@@ -15,6 +15,9 @@ export const initialState: QuickCampaignState = {
   backgroundImageUrl: null,
   segmentCount: 4,
   gamePosition: 'center',
+  advancedMode: false,
+  pointerImage: null,
+  pointerImageUrl: null,
   customColors: {
     primary: '#3B82F6',
     secondary: '#60A5FA',

--- a/src/stores/quickCampaign/types.ts
+++ b/src/stores/quickCampaign/types.ts
@@ -14,6 +14,9 @@ export interface QuickCampaignState {
   backgroundImageUrl: string | null;
   segmentCount: number;
   gamePosition: 'top' | 'center' | 'bottom' | 'left' | 'right';
+  advancedMode: boolean;
+  pointerImage: File | null;
+  pointerImageUrl: string | null;
   customColors: {
     primary: string;
     secondary: string;
@@ -50,6 +53,9 @@ export interface QuickCampaignActions {
   setGamePosition: (position: 'top' | 'center' | 'bottom' | 'left' | 'right') => void;
   setCustomColors: (colors: { primary: string; secondary: string; accent: string; textColor?: string; buttonStyle?: string }) => void;
   setJackpotColors: (colors: any) => void;
+  setAdvancedMode: (mode: boolean) => void;
+  setPointerImage: (file: File | null) => void;
+  setPointerImageUrl: (url: string | null) => void;
   setQuizQuestions: (questions: any[]) => void;
   generatePreviewCampaign: () => any;
   reset: () => void;

--- a/test/quickCampaignStore.test.ts
+++ b/test/quickCampaignStore.test.ts
@@ -16,3 +16,9 @@ test('generatePreviewCampaign reflects segment count', () => {
   const preview = useQuickCampaignStore.getState().generatePreviewCampaign();
   assert.equal(preview.config.roulette.segments.length, 3);
 });
+
+test('pointer image url is included in preview', () => {
+  useQuickCampaignStore.getState().setPointerImageUrl('http://example.com/pointer.png');
+  const preview = useQuickCampaignStore.getState().generatePreviewCampaign();
+  assert.equal(preview.design.pointerImage, 'http://example.com/pointer.png');
+});


### PR DESCRIPTION
## Summary
- introduce expert mode and new pointer customization fields in quick campaign store
- save pointer URL in preview campaign generator
- expose expert mode toggle in the style step header
- allow pointer image upload when expert mode is active
- support custom pointer image in wheel preview
- test pointer image handling

## Testing
- `npm ci` *(fails: missing packages)*
- `npm test` *(fails: missing tsx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68559772ba98832abae4594a622d9982