### PR TITLE
Add Button component and refactor pages

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost";
+}
+
+const base =
+  "inline-flex items-center justify-center rounded-xl font-semibold transition-all duration-300";
+
+const styles = {
+  primary: "bg-brand text-white hover:bg-brand-dark",
+  secondary: "bg-gray-600 text-white hover:bg-gray-700",
+  ghost: "bg-transparent text-brand hover:bg-brand/10",
+};
+
+const Button: React.FC<ButtonProps> = ({
+  variant = "primary",
+  className,
+  ...props
+}) => {
+  return (
+    <button {...props} className={`${base} ${styles[variant]} ${className ?? ""}`}>
+      {props.children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Target, Users } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 import AdminKPICards from '../components/Admin/AdminKPICards';
 import AdminRecentActivity from '../components/Admin/AdminRecentActivity';
 import AdminQuickAccess from '../components/Admin/AdminQuickAccess';
@@ -110,19 +111,23 @@ const Admin: React.FC = () => {
         size="sm"
         actions={
           <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-            <Link
-              to="/admin/templates"
-              className="inline-flex items-center justify-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm whitespace-nowrap"
-            >
-              <Target className="w-5 h-5 mr-2" />
-              Modèles
+            <Link to="/admin/templates">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm whitespace-nowrap"
+              >
+                <Target className="w-5 h-5 mr-2" />
+                Modèles
+              </Button>
             </Link>
-            <Link
-              to="/admin/clients"
-              className="inline-flex items-center justify-center px-6 py-2.5 bg-[#841b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm whitespace-nowrap"
-            >
-              <Users className="w-5 h-5 mr-2" />
-              Gestion Clients
+            <Link to="/admin/clients">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm whitespace-nowrap"
+              >
+                <Users className="w-5 h-5 mr-2" />
+                Gestion Clients
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminAlerts.tsx
+++ b/src/pages/AdminAlerts.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Bell } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminAlerts: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminAlerts: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminAnalytics.tsx
+++ b/src/pages/AdminAnalytics.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, BarChart3 } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminAnalytics: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminAnalytics: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminCampaigns.tsx
+++ b/src/pages/AdminCampaigns.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Target } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminCampaigns: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminCampaigns: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminClientDetail.tsx
+++ b/src/pages/AdminClientDetail.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import Button from '../components/common/Button';
 import PageHeader from '../components/Layout/PageHeader';
 import ClientInfoCard from '../components/Admin/AdminClientDetail/ClientInfoCard';
 import ClientCampaignsTable from '../components/Admin/AdminClientDetail/ClientCampaignsTable';
@@ -78,13 +79,15 @@ const AdminClientDetail: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin/clients"
-              className="inline-flex items-center px-4 sm:px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap"
-            >
-              <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
-              <span className="hidden sm:inline">Retour Clients</span>
-              <span className="sm:hidden">Retour</span>
+            <Link to="/admin/clients">
+              <Button
+                variant="primary"
+                className="px-4 sm:px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap"
+              >
+                <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
+                <span className="hidden sm:inline">Retour Clients</span>
+                <span className="sm:hidden">Retour</span>
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminClients.tsx
+++ b/src/pages/AdminClients.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
+import Button from '../components/common/Button';
 import PageHeader from '../components/Layout/PageHeader';
 import AdminClientsStats from '../components/Admin/AdminClients/AdminClientsStats';
 import AdminClientsFilters from '../components/Admin/AdminClients/AdminClientsFilters';
@@ -74,12 +75,14 @@ const AdminClients: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Admin
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Admin
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminReports.tsx
+++ b/src/pages/AdminReports.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, FileText } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminReports: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminReports: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminSettings.tsx
+++ b/src/pages/AdminSettings.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Settings } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminSettings: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminSettings: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminTeam.tsx
+++ b/src/pages/AdminTeam.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Shield } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const AdminTeam: React.FC = () => {
   return (
@@ -12,12 +13,14 @@ const AdminTeam: React.FC = () => {
         size="sm"
         actions={
           <div className="flex gap-x-4">
-            <Link
-              to="/admin"
-              className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
-            >
-              <ArrowLeft className="w-5 h-5 mr-2" />
-              Retour Dashboard
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
+              >
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Retour Dashboard
+              </Button>
             </Link>
           </div>
         }

--- a/src/pages/AdminTemplates.tsx
+++ b/src/pages/AdminTemplates.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Plus, ArrowLeft } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 import AdminTemplatesStats from '../components/Admin/AdminTemplates/AdminTemplatesStats';
 import AdminTemplatesFilters from '../components/Admin/AdminTemplates/AdminTemplatesFilters';
 import AdminTemplatesGrid from '../components/Admin/AdminTemplates/AdminTemplatesGrid';
@@ -79,19 +80,24 @@ const AdminTemplates: React.FC = () => {
         size="sm"
         actions={
           <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 w-full sm:w-auto">
-            <Link
-              to="/admin"
-              className="inline-flex items-center justify-center px-4 sm:px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap"
-            >
-              <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
-              <span className="hidden sm:inline">Retour Dashboard</span>
-              <span className="sm:hidden">Retour</span>
+            <Link to="/admin">
+              <Button
+                variant="primary"
+                className="px-4 sm:px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap"
+              >
+                <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
+                <span className="hidden sm:inline">Retour Dashboard</span>
+                <span className="sm:hidden">Retour</span>
+              </Button>
             </Link>
-            <button className="inline-flex items-center justify-center px-4 sm:px-6 py-2.5 bg-[#841b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap">
+            <Button
+              variant="primary"
+              className="px-4 sm:px-6 py-2.5 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-sm sm:text-base whitespace-nowrap"
+            >
               <Plus className="w-4 h-4 sm:w-5 sm:h-5 mr-2" />
               <span className="hidden sm:inline">Créer un Modèle</span>
               <span className="sm:hidden">Créer</span>
-            </button>
+            </Button>
           </div>
         }
       />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import Button from '../components/common/Button';
 import logo from '@/assets/logo.png';
 
 const Login: React.FC = () => {
@@ -94,12 +95,13 @@ const Login: React.FC = () => {
             </div>
 
             {/* Bouton de connexion */}
-            <button
+            <Button
               type="submit"
-              className="w-full bg-[#841b60] text-white py-3 px-4 rounded-xl font-semibold hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+              variant="primary"
+              className="w-full py-3 px-4 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
             >
               Se connecter
-            </button>
+            </Button>
           </form>
 
           {/* Séparateur */}
@@ -110,12 +112,13 @@ const Login: React.FC = () => {
           </div>
 
           {/* Accès admin */}
-          <button
+          <Button
             onClick={handleAdminLogin}
-            className="w-full bg-gray-600 text-white py-3 px-4 rounded-xl font-semibold hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+            variant="primary"
+            className="w-full py-3 px-4 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
           >
             Accès Administrateur
-          </button>
+          </Button>
 
           {/* Liens */}
           <div className="mt-6 text-center space-y-2">

--- a/src/pages/Social.tsx
+++ b/src/pages/Social.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BarChart2, AlertCircle, Plus } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const Social: React.FC = () => {
   return (
@@ -9,10 +10,10 @@ const Social: React.FC = () => {
         title="Réseaux sociaux"
         size="sm"
         actions={
-          <button className="inline-flex items-center bg-[#841b60] text-white font-semibold hover:bg-[#6d164f] transition-all duration-300">
+          <Button variant="primary" className="px-4 py-2">
             <Plus className="w-5 h-5 mr-2" />
             Nouvelle Publication
-          </button>
+          </Button>
         }
       />
 
@@ -54,9 +55,9 @@ const Social: React.FC = () => {
                     <option>Commentaires</option>
                     <option>Partages</option>
                   </select>
-                  <button className="px-4 py-2 bg-[#841b60] text-white font-medium rounded-lg hover:bg-[#6d164f] transition-colors duration-200">
+                  <Button variant="primary" className="px-4 py-2 font-medium rounded-lg">
                     Comparer
-                  </button>
+                  </Button>
                 </div>
                 <div className="h-64 border border-gray-200 rounded-lg flex items-center justify-center">
                   <BarChart2 className="w-8 h-8 text-gray-300" />

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { BarChart3, LineChart, PieChart, Users, Target, ArrowUpRight, Calendar, Download } from 'lucide-react';
 import PageHeader from '../components/Layout/PageHeader';
+import Button from '../components/common/Button';
 
 const Statistics: React.FC = () => {
   const [period, setPeriod] = useState('30');
@@ -20,10 +21,13 @@ const Statistics: React.FC = () => {
               <option value="90">90 derniers jours</option>
               <option value="365">Cette année</option>
             </select>
-            <button className="inline-flex items-center px-8 py-4 bg-[#841b60] text-white font-semibold rounded-2xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+            <Button
+              variant="primary"
+              className="px-8 py-4 shadow-lg hover:shadow-xl transform hover:-translate-y-1"
+            >
               <Download className="w-5 h-5 mr-2" />
               Exporter
-            </button>
+            </Button>
           </div>
         }
       />


### PR DESCRIPTION
## Summary
- add a reusable `Button` component
- replace repeated button classes in pages with `<Button variant="primary">`

## Testing
- `npm ci` *(fails: missing packages)*
- `npm test` *(fails: missing dependency tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685601725a34832aa30254b68d582821