### PR TITLE
Improve modern campaign editor responsiveness

### DIFF
--- a/src/components/ModernEditor/ModernEditorLayout.tsx
+++ b/src/components/ModernEditor/ModernEditorLayout.tsx
@@ -58,9 +58,9 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
       />
 
       {/* Main Content */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden flex-col lg:flex-row">
         {/* Editor Sidebar - largeur augmentée de 15% supplémentaire */}
-        <div className="bg-white/95 backdrop-blur-sm border-r border-gray-200/50 shadow-sm flex-shrink-0 px-0 mx-[2px]" style={{ width: '310px' }}>
+        <div className="bg-white/95 backdrop-blur-sm border-r border-gray-200/50 shadow-sm flex-shrink-0 px-0 mx-[2px] w-full sm:w-64 md:w-72 lg:w-80 overflow-y-auto">
           <div className="flex h-full">
             {/* Navigation tabs - alignés à gauche */}
             <div className="w-16 border-r border-gray-200/50 flex-shrink-0">
@@ -94,13 +94,9 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
           </div>
 
           {/* Zone de prévisualisation - dimensions absolues fixes */}
-          <div className="flex-1 flex items-center justify-center p-4 overflow-hidden">
-            <div 
-              className="bg-white rounded-xl shadow-lg border border-gray-200/50 overflow-hidden flex-shrink-0"
-              style={{
-                width: '1200px',
-                height: '800px'
-              }}
+          <div className="flex-1 flex items-center justify-center p-4 overflow-auto">
+            <div
+              className="bg-white rounded-xl shadow-lg border border-gray-200/50 overflow-hidden flex-shrink-0 w-full max-w-[1200px] h-full max-h-[80vh]"
             >
               <GameCanvasPreview
                 campaign={campaign}

--- a/src/components/ModernEditor/ModernPreviewModal.tsx
+++ b/src/components/ModernEditor/ModernPreviewModal.tsx
@@ -27,7 +27,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
       case 'tablet':
         return { width: '768px', height: '1024px' };
       default:
-        return { width: '1200px', height: '800px' };
+        return { width: '100%', maxWidth: '1200px', height: '100%', maxHeight: '800px' };
     }
   };
 
@@ -102,6 +102,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
                 className={`p-2 rounded-md transition-colors ${
                   device === 'desktop' ? 'bg-white shadow-sm' : 'hover:bg-gray-200'
                 }`}
+                aria-label="Desktop"
               >
                 <Monitor className="w-4 h-4" />
               </button>
@@ -110,6 +111,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
                 className={`p-2 rounded-md transition-colors ${
                   device === 'tablet' ? 'bg-white shadow-sm' : 'hover:bg-gray-200'
                 }`}
+                aria-label="Tablette"
               >
                 <Tablet className="w-4 h-4" />
               </button>
@@ -118,6 +120,7 @@ const ModernPreviewModal: React.FC<ModernPreviewModalProps> = ({
                 className={`p-2 rounded-md transition-colors ${
                   device === 'mobile' ? 'bg-white shadow-sm' : 'hover:bg-gray-200'
                 }`}
+                aria-label="Mobile"
               >
                 <Smartphone className="w-4 h-4" />
               </button>

--- a/src/components/ModernEditor/components/EditorHeader.tsx
+++ b/src/components/ModernEditor/components/EditorHeader.tsx
@@ -23,13 +23,13 @@ const EditorHeader: React.FC<EditorHeaderProps> = ({
   onDeviceChange = () => {}
 }) => {
   return (
-    <div className="bg-white/95 backdrop-blur-sm border-b border-gray-100 flex-shrink-0 z-50">
+    <div className="sticky top-0 bg-white/95 backdrop-blur-sm border-b border-gray-100 flex-shrink-0 z-50">
       <div className="px-6 py-4">
         <div className="flex items-center justify-between">
           {/* Left section - Titre de la campagne */}
           <div className="flex items-center space-x-4 flex-shrink-0">
             <div className="flex-1 min-w-0">
-              <h1 className="text-xl font-bold text-gray-900 truncate">
+              <h1 className="text-xl font-bold text-gray-900 break-words whitespace-normal">
                 {campaign.name || (isNewCampaign ? 'Nouvelle Campagne' : 'Campagne')}
               </h1>
               <div className="flex items-center space-x-2 text-sm text-gray-500">

--- a/src/components/ModernEditor/components/PreviewDeviceButtons.tsx
+++ b/src/components/ModernEditor/components/PreviewDeviceButtons.tsx
@@ -16,33 +16,36 @@ const PreviewDeviceButtons: React.FC<PreviewDeviceButtonsProps> = ({
       <button
         onClick={() => onDeviceChange('desktop')}
         className={`p-2 rounded-md transition-colors ${
-          selectedDevice === 'desktop' 
-            ? 'bg-white shadow-sm text-[#841b60]' 
+          selectedDevice === 'desktop'
+            ? 'bg-white shadow-sm text-[#841b60]'
             : 'text-gray-600 hover:text-gray-900'
         }`}
         title="Desktop"
+        aria-label="Desktop"
       >
         <Monitor className="w-4 h-4" />
       </button>
       <button
         onClick={() => onDeviceChange('tablet')}
         className={`p-2 rounded-md transition-colors ${
-          selectedDevice === 'tablet' 
-            ? 'bg-white shadow-sm text-[#841b60]' 
+          selectedDevice === 'tablet'
+            ? 'bg-white shadow-sm text-[#841b60]'
             : 'text-gray-600 hover:text-gray-900'
         }`}
         title="Tablette"
+        aria-label="Tablette"
       >
         <Tablet className="w-4 h-4" />
       </button>
       <button
         onClick={() => onDeviceChange('mobile')}
         className={`p-2 rounded-md transition-colors ${
-          selectedDevice === 'mobile' 
-            ? 'bg-white shadow-sm text-[#841b60]' 
+          selectedDevice === 'mobile'
+            ? 'bg-white shadow-sm text-[#841b60]'
             : 'text-gray-600 hover:text-gray-900'
         }`}
         title="Mobile"
+        aria-label="Mobile"
       >
         <Smartphone className="w-4 h-4" />
       </button>


### PR DESCRIPTION
## Summary
- make editor layout responsive with flexible widths
- adjust preview modal to use max width/height and add accessible labels
- make header sticky, allow long titles to wrap
- add aria labels for device buttons

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685876e22fcc832ab6bccc444c0ebb19