### PR TITLE
Improve campaign editor settings

### DIFF
--- a/src/components/CampaignEditor/CampaignEditorTabs.tsx
+++ b/src/components/CampaignEditor/CampaignEditorTabs.tsx
@@ -9,7 +9,7 @@ interface CampaignEditorTabsProps {
 const CampaignEditorTabs: React.FC<CampaignEditorTabsProps> = ({ activeTab, onTabChange }) => {
   const tabs = [
     { id: 'general', label: 'Général', icon: '⚙️' },
-    { id: 'content', label: 'Contenu et apparences', icon: '📝' },
+    { id: 'content', label: 'Design & Contenu', icon: '🎨' },
     { id: 'mobile', label: 'Mobile', icon: '📱' },    
     { id: 'screens', label: 'Écrans', icon: '📱' },
     { id: 'form', label: 'Formulaire', icon: '📝' },

--- a/src/components/CampaignEditor/CampaignGeneral.tsx
+++ b/src/components/CampaignEditor/CampaignGeneral.tsx
@@ -8,9 +8,12 @@ interface CampaignGeneralProps {
 }
 
 const CampaignGeneral: React.FC<CampaignGeneralProps> = ({ campaign, setCampaign }) => {
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setCampaign((prev: any) => ({ ...prev, [name]: value }));
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value, type, checked } = e.target as HTMLInputElement;
+    const newValue = type === 'checkbox' ? checked : value;
+    setCampaign((prev: any) => ({ ...prev, [name]: newValue }));
   };
   
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -171,7 +174,40 @@ const CampaignGeneral: React.FC<CampaignGeneralProps> = ({ campaign, setCampaign
             </div>
           </div>
         </div>
-        
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="timezone" className="block text-sm font-medium text-gray-700 mb-1">
+              Fuseau horaire
+            </label>
+            <select
+              id="timezone"
+              name="timezone"
+              value={campaign.timezone || 'Europe/Paris'}
+              onChange={handleInputChange}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+            >
+              <option value="Europe/Paris">Europe/Paris</option>
+              <option value="America/New_York">America/New_York</option>
+              <option value="Asia/Tokyo">Asia/Tokyo</option>
+            </select>
+          </div>
+
+          <div className="flex items-center space-x-2 mt-6">
+            <input
+              id="autoSchedule"
+              type="checkbox"
+              name="autoSchedule"
+              checked={campaign.autoSchedule || false}
+              onChange={handleInputChange}
+              className="h-4 w-4 text-[#841b60] border-gray-300 rounded focus:ring-[#841b60]"
+            />
+            <label htmlFor="autoSchedule" className="text-sm text-gray-700">
+              Activer la planification automatique
+            </label>
+          </div>
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">

--- a/src/components/CampaignEditor/CampaignSettings.tsx
+++ b/src/components/CampaignEditor/CampaignSettings.tsx
@@ -14,14 +14,14 @@ const CampaignSettings: React.FC<CampaignSettingsProps> = ({ campaign, setCampai
           Configurez les paramètres avancés de votre campagne.
         </p>
       </div>
-      
+
       <div className="space-y-4">
         <h3 className="text-lg font-medium text-gray-900">Paramètres de la campagne</h3>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Mode de récompense
+              Méthode de distribution des lots
             </label>
             <select
               value={campaign.rewards?.mode || 'probability'}
@@ -51,6 +51,63 @@ const CampaignSettings: React.FC<CampaignSettingsProps> = ({ campaign, setCampai
                 rewards: { ...prev.rewards, probability: Number(e.target.value) }
               }))}
               className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+            />
+          </div>
+
+          <div className="flex items-center space-x-2 mt-2">
+            <input
+              id="previewEnabled"
+              type="checkbox"
+              checked={campaign.previewEnabled || false}
+              onChange={(e) =>
+                setCampaign((prev: any) => ({
+                  ...prev,
+                  previewEnabled: e.target.checked
+                }))
+              }
+              className="h-4 w-4 text-[#841b60] border-gray-300 rounded focus:ring-[#841b60]"
+            />
+            <label htmlFor="previewEnabled" className="text-sm text-gray-700">
+              Aperçu en temps réel
+            </label>
+          </div>
+
+          <div className="flex items-center space-x-2 mt-2">
+            <input
+              id="highContrast"
+              type="checkbox"
+              checked={campaign.accessibility?.highContrast || false}
+              onChange={(e) =>
+                setCampaign((prev: any) => ({
+                  ...prev,
+                  accessibility: {
+                    ...prev.accessibility,
+                    highContrast: e.target.checked
+                  }
+                }))
+              }
+              className="h-4 w-4 text-[#841b60] border-gray-300 rounded focus:ring-[#841b60]"
+            />
+            <label htmlFor="highContrast" className="text-sm text-gray-700">
+              Mode contraste renforcé
+            </label>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              ID Google Analytics
+            </label>
+            <input
+              type="text"
+              value={campaign.analytics?.gaId || ''}
+              onChange={(e) =>
+                setCampaign((prev: any) => ({
+                  ...prev,
+                  analytics: { ...prev.analytics, gaId: e.target.value }
+                }))
+              }
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#841b60]"
+              placeholder="G-XXXXXXXXXX"
             />
           </div>
         </div>

--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -6,6 +6,8 @@ import FunnelUnlockedGame from '../funnels/FunnelUnlockedGame';
 import FunnelStandard from '../funnels/FunnelStandard';
 import { GameSize } from '../configurators/GameSizeSelector';
 import { createSynchronizedQuizCampaign } from '../../utils/quizConfigSync';
+import { useGamePositionCalculator } from './GamePositionCalculator';
+import useCenteredStyles from '../../hooks/useCenteredStyles';
 
 interface GameRendererProps {
   campaign: any;
@@ -27,12 +29,20 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   className = ''
 }) => {
   // Utiliser le système de synchronisation pour le quiz
-  const enhancedCampaign = campaign.type === 'quiz' 
+  const enhancedCampaign = campaign.type === 'quiz'
     ? createSynchronizedQuizCampaign(campaign)
     : campaign;
 
   // Types de jeux utilisant le funnel unlocked_game
   const unlockedTypes = ['wheel', 'scratch', 'jackpot', 'dice'];
+
+  const gamePosition = enhancedCampaign.gamePosition || 'center';
+  const { containerStyle: baseContainerStyle, wrapperStyle } = useCenteredStyles();
+  const { getPositionStyles } = useGamePositionCalculator({
+    gameSize,
+    gamePosition,
+    shouldCropWheel: false
+  });
   
   // Déterminer le funnel à utiliser
   const shouldUseUnlockedFunnel = unlockedTypes.includes(enhancedCampaign.type) || 
@@ -40,12 +50,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
   // Style du conteneur principal
   const containerStyle: React.CSSProperties = {
-    width: '100%',
-    height: '100%',
-    minHeight: '400px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    ...baseContainerStyle,
     backgroundColor: enhancedCampaign.design?.background || '#f8fafc',
     position: 'relative',
     overflow: 'hidden'
@@ -67,10 +72,15 @@ const GameRenderer: React.FC<GameRendererProps> = ({
         {gameBackgroundImage && (
           <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
         )}
-        <div className="relative z-10 w-full h-full">
-          <FunnelStandard 
+        <div
+          className="relative z-10"
+          style={{ ...wrapperStyle, ...getPositionStyles() }}
+        >
+          <FunnelStandard
             campaign={enhancedCampaign}
-            key={`standard-${enhancedCampaign.type}-${JSON.stringify(enhancedCampaign.gameConfig)}`}
+            key={`standard-${enhancedCampaign.type}-${JSON.stringify(
+              enhancedCampaign.gameConfig
+            )}`}
           />
         </div>
       </div>
@@ -84,7 +94,10 @@ const GameRenderer: React.FC<GameRendererProps> = ({
         {gameBackgroundImage && (
           <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
         )}
-        <div className="relative z-10 w-full h-full">
+        <div
+          className="relative z-10"
+          style={{ ...wrapperStyle, ...getPositionStyles() }}
+        >
           <FunnelUnlockedGame
             campaign={enhancedCampaign}
             previewMode={previewDevice === 'desktop' ? 'desktop' : previewDevice}
@@ -164,7 +177,10 @@ const GameRenderer: React.FC<GameRendererProps> = ({
       {gameBackgroundImage && (
         <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
       )}
-      <div className="relative z-10 w-full h-full flex items-center justify-center">
+      <div
+        className="relative z-10 flex items-center justify-center"
+        style={{ ...wrapperStyle, ...getPositionStyles() }}
+      >
         {renderDirectGame()}
       </div>
     </div>

--- a/src/hooks/useGameSize.ts
+++ b/src/hooks/useGameSize.ts
@@ -1,24 +1,8 @@
-
 import { useMemo } from 'react';
-
-export type GameSize = 'small' | 'medium' | 'large' | 'xlarge';
-
+import { GAME_SIZES, GameSize } from '../components/configurators/GameSizeSelector';
 export const useGameSize = (size: GameSize = 'medium') => {
   const getGameDimensions = useMemo(() => {
-    return () => {
-      switch (size) {
-        case 'small':
-          return { width: 200, height: 200 };
-        case 'medium':
-          return { width: 300, height: 300 };
-        case 'large':
-          return { width: 400, height: 400 };
-        case 'xlarge':
-          return { width: 500, height: 500 };
-        default:
-          return { width: 300, height: 300 };
-      }
-    };
+    return () => GAME_SIZES[size];
   }, [size]);
 
   const getContainerDimensions = useMemo(() => {


### PR DESCRIPTION
## Summary
- add preview toggle, GA tracking ID field and high contrast option
- support timezone selection and scheduling toggle
- tweak tab label for design
- fix game size preview so selected dimensions apply

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859640d6880832aaf5ce8a8f8320c01