### PR TITLE
Fix preview form duplication and wheel sizing

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import GameRenderer from './GameRenderer';
-import { GameSize } from '../configurators/GameSizeSelector';
+import { GameSize, GAME_SIZES } from '../configurators/GameSizeSelector';
 import { getCampaignBackgroundImage } from '../../utils/background';
 
 interface GameCanvasPreviewProps {
@@ -36,8 +36,11 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   };
 
   const getContainerStyle = () => {
+    const dimensions = GAME_SIZES[gameSize];
+    const baseMinHeight = Math.max(dimensions.height + 100, 400);
+
     const baseStyle: React.CSSProperties = {
-      minHeight: '400px',
+      minHeight: `${baseMinHeight}px`,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -48,20 +51,20 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
       return {
         ...baseStyle,
         padding: '16px',
-        minHeight: '600px'
+        minHeight: `${Math.max(baseMinHeight, 600)}px`
       };
     } else if (previewDevice === 'tablet') {
       return {
         ...baseStyle,
         padding: '24px',
-        minHeight: '500px'
+        minHeight: `${Math.max(baseMinHeight, 500)}px`
       };
     }
 
     return {
       ...baseStyle,
       padding: '32px',
-      minHeight: '400px'
+      minHeight: `${baseMinHeight}px`
     };
   };
 

--- a/src/components/GameTypes/WheelComponents/WheelPreviewLogic.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewLogic.tsx
@@ -21,6 +21,7 @@ interface UseWheelPreviewLogicProps {
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
+  disableForm?: boolean;
 }
 
 const getWheelDimensions = (
@@ -64,9 +65,10 @@ export const useWheelPreviewLogic = ({
   onStart,
   gameSize = 'small',
   gamePosition = 'center',
-  previewDevice = 'desktop'
+  previewDevice = 'desktop',
+  disableForm = false
 }: UseWheelPreviewLogicProps) => {
-  const [formValidated, setFormValidated] = useState(false);
+  const [formValidated, setFormValidated] = useState(disableForm);
   const [showFormModal, setShowFormModal] = useState(false);
   const [showValidationMessage, setShowValidationMessage] = useState(false);
 
@@ -144,6 +146,10 @@ export const useWheelPreviewLogic = ({
     }
 
     if (!formValidated) {
+      if (disableForm) {
+        // When form handling is external, do nothing here
+        return;
+      }
       setShowFormModal(true);
       return;
     }

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -23,6 +23,7 @@ interface WheelPreviewProps {
   gameSize?: 'small' | 'medium' | 'large' | 'xlarge';
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
+  disableForm?: boolean;
 }
 
 const WheelPreview: React.FC<WheelPreviewProps> = ({
@@ -33,7 +34,8 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   onStart,
   gameSize = 'small',
   gamePosition = 'center',
-  previewDevice = 'desktop'
+  previewDevice = 'desktop',
+  disableForm = false
 }) => {
   const {
     formValidated,
@@ -61,7 +63,8 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
     onStart,
     gameSize,
     gamePosition,
-    previewDevice
+    previewDevice,
+    disableForm
   });
 
   const {
@@ -130,14 +133,16 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
         </div>
       </div>
 
-      <WheelFormModal
-        showFormModal={showFormModal}
-        onClose={() => setShowFormModal(false)}
-        campaign={campaign}
-        fields={fields}
-        participationLoading={participationLoading}
-        onSubmit={handleFormSubmit}
-      />
+      {!disableForm && (
+        <WheelFormModal
+          showFormModal={showFormModal}
+          onClose={() => setShowFormModal(false)}
+          campaign={campaign}
+          fields={fields}
+          participationLoading={participationLoading}
+          onSubmit={handleFormSubmit}
+        />
+      )}
     </WheelContainer>
   );
 };

--- a/src/components/funnels/FunnelUnlockedGame.tsx
+++ b/src/components/funnels/FunnelUnlockedGame.tsx
@@ -136,17 +136,19 @@ const FunnelUnlockedGame: React.FC<FunnelUnlockedGameProps> = ({
       />
 
       {/* Modal de formulaire */}
-      <FormHandler 
-        showFormModal={showFormModal} 
-        campaign={campaign} 
-        fields={fields} 
-        participationLoading={participationLoading} 
-        modalContained={modalContained} 
-        onClose={() => {
-          setShowFormModal(false);
-        }} 
-        onSubmit={handleFormSubmit} 
-      />
+      {campaign.type !== 'wheel' && (
+        <FormHandler
+          showFormModal={showFormModal}
+          campaign={campaign}
+          fields={fields}
+          participationLoading={participationLoading}
+          modalContained={modalContained}
+          onClose={() => {
+            setShowFormModal(false);
+          }}
+          onSubmit={handleFormSubmit}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -79,6 +79,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             gamePosition={gamePosition}
             previewDevice={previewMode}
             disabled={!formValidated}
+            disableForm={true}
           />
         );
       


### PR DESCRIPTION
## Summary
- avoid rendering duplicate form modal for wheel preview in unlocked funnel
- allow external form handling in wheel preview logic
- ensure wheel preview skips internal form when disabled
- adapt preview canvas height to game size for large wheels

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ac99ba40832a911ffd40fef77677