### PR TITLE
Increase wheel preview size limit

### DIFF
--- a/src/components/QuickCampaign/Preview/utils/previewConstraints.ts
+++ b/src/components/QuickCampaign/Preview/utils/previewConstraints.ts
@@ -25,7 +25,7 @@ export const DEVICE_CONSTRAINTS = {
 export const GAME_CONSTRAINTS = {
   wheel: {
     minSize: 200,
-    maxSize: 400,
+    maxSize: 500,
     defaultSize: 300,
   },
   jackpot: {

--- a/test/previewConstraints.test.ts
+++ b/test/previewConstraints.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateConstrainedSize, GAME_CONSTRAINTS } from '../src/components/QuickCampaign/Preview/utils/previewConstraints';
+
+test('calculateConstrainedSize allows larger wheel size', () => {
+  const result = calculateConstrainedSize(600, 600, 'wheel');
+  assert.equal(result.width, GAME_CONSTRAINTS.wheel.maxSize);
+  assert.equal(result.height, GAME_CONSTRAINTS.wheel.maxSize);
+});


### PR DESCRIPTION
## Summary
- let wheel previews grow up to 500px
- cover `calculateConstrainedSize` with a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b048b770832abf454bfe6220a50a