### PR TITLE
Fix GameCanvasPreview overflow

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -24,7 +24,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
     gameBackgroundImage || getCampaignBackgroundImage(campaign, previewDevice);
 
   const getContainerClasses = () => {
-    const baseClasses = "bg-white border-2 border-gray-200 overflow-hidden";
+    const baseClasses = "bg-white border-2 border-gray-200 overflow-visible";
     
     if (previewDevice === 'mobile') {
       return `${baseClasses} rounded-3xl shadow-2xl`;

--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -53,7 +53,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
     ...baseContainerStyle,
     backgroundColor: enhancedCampaign.design?.background || '#f8fafc',
     position: 'relative',
-    overflow: 'hidden'
+    overflow: 'visible'
   };
 
   // Ajouter l'image de fond si définie


### PR DESCRIPTION
## Summary
- ensure GameCanvasPreview container uses `overflow-visible`
- allow game renderer container overflow visible to keep wheels visible

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859b04af278832a9558d0f5e8d8d498