### PR TITLE
Fix wheel preview overlay

### DIFF
--- a/src/components/CampaignEditor/CampaignPreview.tsx
+++ b/src/components/CampaignEditor/CampaignPreview.tsx
@@ -46,6 +46,7 @@ const CampaignPreview: React.FC<CampaignPreviewProps> = ({ campaign, previewDevi
               previewDevice={previewDevice}
               buttonLabel={campaign.buttonConfig?.text || 'Jouer'}
               buttonColor={campaign.buttonConfig?.color || '#841b60'}
+              showBackgroundOverlay={false}
             />
           </div>
         </div>

--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -8,6 +8,11 @@ interface GameCanvasPreviewProps {
   campaign: any;
   gameSize: GameSize;
   gameBackgroundImage?: string;
+  /**
+   * Display a dark overlay between the background image and the game.
+   * Defaults to false to show the raw background.
+   */
+  showBackgroundOverlay?: boolean;
   className?: string;
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
 }
@@ -17,7 +22,8 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
   gameSize,
   gameBackgroundImage,
   className = '',
-  previewDevice = 'desktop'
+  previewDevice = 'desktop',
+  showBackgroundOverlay = false
 }) => {
   // Résoudre l'image de fond à afficher (priorité à la prop, fallback sur config)
   const resolvedBackground =
@@ -83,6 +89,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
         buttonLabel={campaign.buttonConfig?.text || campaign.gameConfig?.[campaign.type]?.buttonLabel}
         buttonColor={campaign.buttonConfig?.color || campaign.gameConfig?.[campaign.type]?.buttonColor || '#841b60'}
         gameBackgroundImage={resolvedBackground}
+        showBackgroundOverlay={showBackgroundOverlay}
         className="w-full h-full flex items-center justify-center"
       />
     </div>

--- a/src/components/CampaignEditor/GameRenderer.tsx
+++ b/src/components/CampaignEditor/GameRenderer.tsx
@@ -17,6 +17,11 @@ interface GameRendererProps {
   buttonLabel?: string;
   buttonColor?: string;
   gameBackgroundImage?: string;
+  /**
+   * Display a dark overlay between the background image and the game content.
+   * Disabled by default to keep the background fully visible.
+   */
+  showBackgroundOverlay?: boolean;
   className?: string;
 }
 
@@ -27,6 +32,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   buttonLabel,
   buttonColor,
   gameBackgroundImage,
+  showBackgroundOverlay = false,
   className = ''
 }) => {
   // Utiliser le système de synchronisation pour le quiz
@@ -75,7 +81,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   if (enhancedCampaign.type === 'form' || enhancedCampaign.type === 'quiz') {
     return (
       <div className={className} style={containerStyle}>
-        {gameBackgroundImage && (
+        {gameBackgroundImage && showBackgroundOverlay && (
           <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
         )}
         <div
@@ -97,7 +103,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
   if (shouldUseUnlockedFunnel) {
     return (
       <div className={className} style={containerStyle}>
-        {gameBackgroundImage && (
+        {gameBackgroundImage && showBackgroundOverlay && (
           <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
         )}
         <div
@@ -181,7 +187,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
 
   return (
     <div className={className} style={containerStyle}>
-      {gameBackgroundImage && (
+      {gameBackgroundImage && showBackgroundOverlay && (
         <div className="absolute inset-0 bg-black/20" style={{ zIndex: 1 }} />
       )}
       <div

--- a/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
@@ -24,6 +24,11 @@ interface WheelPreviewContentProps {
   formValidated: boolean;
   showValidationMessage: boolean;
   onWheelClick: () => void;
+  /**
+   * Display the default radial shadow behind the wheel.
+   * Enabled by default for a subtle depth effect.
+   */
+  showShadow?: boolean;
 }
 
 const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
@@ -43,7 +48,8 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
   gamePosition,
   formValidated,
   showValidationMessage,
-  onWheelClick
+  onWheelClick,
+  showShadow = true
 }) => {
   // Assurer que le canvas ne dépasse jamais du conteneur
   const constrainedCanvasSize = Math.min(
@@ -87,19 +93,21 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
   return (
     <div style={getContainerStyle()}>
       {/* Ombre de la roue */}
-      <div 
-        style={{
-          position: 'absolute',
-          width: constrainedCanvasSize - 20,
-          height: constrainedCanvasSize - 20,
-          left: wheelOffset.left + 10,
-          top: wheelOffset.top + 15,
-          borderRadius: '50%',
-          background: 'radial-gradient(circle, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.05) 50%, transparent 70%)',
-          filter: 'blur(8px)',
-          zIndex: 0
-        }}
-      />
+      {showShadow && (
+        <div
+          style={{
+            position: 'absolute',
+            width: constrainedCanvasSize - 20,
+            height: constrainedCanvasSize - 20,
+            left: wheelOffset.left + 10,
+            top: wheelOffset.top + 15,
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.05) 50%, transparent 70%)',
+            filter: 'blur(8px)',
+            zIndex: 0
+          }}
+        />
+      )}
       
       <WheelInteractionHandler
         formValidated={formValidated}

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -24,6 +24,8 @@ interface WheelPreviewProps {
   gamePosition?: 'top' | 'center' | 'bottom' | 'left' | 'right';
   previewDevice?: 'desktop' | 'tablet' | 'mobile';
   disableForm?: boolean;
+  /** Control display of the radial shadow under the wheel */
+  showShadow?: boolean;
 }
 
 const WheelPreview: React.FC<WheelPreviewProps> = ({
@@ -35,7 +37,8 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   gameSize = 'small',
   gamePosition = 'center',
   previewDevice = 'desktop',
-  disableForm = false
+  disableForm = false,
+  showShadow = true
 }) => {
   const {
     formValidated,
@@ -119,6 +122,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
             formValidated={formValidated}
             showValidationMessage={showValidationMessage}
             onWheelClick={handleWheelClick}
+            showShadow={showShadow}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- add `showBackgroundOverlay` prop to GameRenderer and preview components
- expose `showShadow` prop to WheelPreview and WheelPreviewContent
- default overlays off in campaign preview

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859b6fd320c832a88adea23c2d55420