### PR TITLE
Fix wheel preview action

### DIFF
--- a/src/components/funnels/FunnelUnlockedGame.tsx
+++ b/src/components/funnels/FunnelUnlockedGame.tsx
@@ -27,7 +27,9 @@ const FunnelUnlockedGame: React.FC<FunnelUnlockedGameProps> = ({
   mobileConfig,
   modalContained = true
 }) => {
-  const [formValidated, setFormValidated] = useState(false);
+  // Wheel games do not require any form validation. Initialize the
+  // validation state accordingly so the game can be launched directly.
+  const [formValidated, setFormValidated] = useState(campaign.type === 'wheel');
   const [showFormModal, setShowFormModal] = useState(false);
   const [showValidationMessage, setShowValidationMessage] = useState(false);
   const [gameResult, setGameResult] = useState<'win' | 'lose' | null>(null);


### PR DESCRIPTION
## Summary
- allow wheel games to start without form submission by default

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859b95d5fe4832aaa4b6b7727dda09b