### PR TITLE
Fix Unlocked funnel gating

### DIFF
--- a/src/components/GameTypes/Jackpot/JackpotControls.tsx
+++ b/src/components/GameTypes/Jackpot/JackpotControls.tsx
@@ -9,6 +9,7 @@ interface JackpotControlsProps {
   buttonLabel: string;
   buttonColor: string;
   borderColor: string;
+  disabled?: boolean;
 }
 
 const JackpotControls: React.FC<JackpotControlsProps> = ({
@@ -34,10 +35,10 @@ const JackpotControls: React.FC<JackpotControlsProps> = ({
   }
 
   return (
-    <button 
-      onClick={onRoll} 
-      disabled={isRolling} 
-      className="px-6 py-3 text-white font-medium rounded-lg transition-all duration-200 disabled:opacity-50 max-w-full" 
+    <button
+      onClick={onRoll}
+      disabled={isRolling || disabled}
+      className="px-6 py-3 text-white font-medium rounded-lg transition-all duration-200 disabled:opacity-50 max-w-full"
       style={{
         backgroundColor: buttonColor,
         fontSize: 'clamp(14px, 3.5vw, 18px)',

--- a/src/components/GameTypes/Jackpot/index.tsx
+++ b/src/components/GameTypes/Jackpot/index.tsx
@@ -12,6 +12,7 @@ const Jackpot: React.FC<JackpotProps> = ({
   instantWinConfig,
   onFinish,
   onStart,
+  disabled = false,
   buttonLabel = "Lancer le Jackpot",
   buttonColor = "#ec4899",
   backgroundImage,
@@ -30,7 +31,7 @@ const Jackpot: React.FC<JackpotProps> = ({
 
 
   const roll = () => {
-    if (isRolling || result) return;
+    if (isRolling || result || disabled) return;
     
     onStart?.();
     
@@ -169,6 +170,7 @@ const Jackpot: React.FC<JackpotProps> = ({
           buttonLabel={buttonLabel}
           buttonColor={buttonColor}
           borderColor={borderColor}
+          disabled={disabled}
         />
       </div>
     </div>

--- a/src/components/GameTypes/Jackpot/types.ts
+++ b/src/components/GameTypes/Jackpot/types.ts
@@ -11,6 +11,8 @@ export interface JackpotProps {
   instantWinConfig?: JackpotInstantWinConfig;
   onFinish?: (result: 'win' | 'lose') => void;
   onStart?: () => void;
+  /** Désactive le démarrage du jackpot (formulaire non validé) */
+  disabled?: boolean;
   buttonLabel?: string;
   buttonColor?: string;
   backgroundImage?: string;

--- a/src/components/funnels/FunnelUnlockedGame.tsx
+++ b/src/components/funnels/FunnelUnlockedGame.tsx
@@ -33,9 +33,10 @@ const FunnelUnlockedGame: React.FC<FunnelUnlockedGameProps> = ({
     console.warn(`Type de jeu "${campaign.type}" utilise FunnelUnlockedGame mais devrait utiliser FunnelStandard`);
   }
 
-  // Wheel games do not require any form validation. Initialize the
-  // validation state accordingly so the game can be launched directly.
-  const [formValidated, setFormValidated] = useState(campaign.type === 'wheel');
+  // L'état de validation du formulaire démarre toujours à false pour
+  // obliger l'utilisateur à renseigner le formulaire avant de jouer,
+  // quel que soit le type de jeu.
+  const [formValidated, setFormValidated] = useState(false);
   const [showFormModal, setShowFormModal] = useState(false);
   const [showValidationMessage, setShowValidationMessage] = useState(false);
   const [gameResult, setGameResult] = useState<'win' | 'lose' | null>(null);

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -110,13 +110,14 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             containerBackgroundColor={campaign.gameConfig?.jackpot?.containerBackgroundColor}
             backgroundColor={campaign.gameConfig?.jackpot?.backgroundColor}
             borderColor={campaign.gameConfig?.jackpot?.borderColor}
-            borderWidth={campaign.gameConfig?.jackpot?.borderWidth}
-            slotBorderColor={campaign.gameConfig?.jackpot?.slotBorderColor}
-            slotBorderWidth={campaign.gameConfig?.jackpot?.slotBorderWidth}
-            slotBackgroundColor={campaign.gameConfig?.jackpot?.slotBackgroundColor}
-            onFinish={handleGameComplete}
-            onStart={handleGameStartInternal}
-          />
+          borderWidth={campaign.gameConfig?.jackpot?.borderWidth}
+          slotBorderColor={campaign.gameConfig?.jackpot?.slotBorderColor}
+          slotBorderWidth={campaign.gameConfig?.jackpot?.slotBorderWidth}
+          slotBackgroundColor={campaign.gameConfig?.jackpot?.slotBackgroundColor}
+          disabled={!formValidated}
+          onFinish={handleGameComplete}
+          onStart={handleGameStartInternal}
+        />
         );
       case 'quiz':
         return (


### PR DESCRIPTION
## Summary
- start unlocked games with form validation disabled
- allow jackpot to disable play button when form isn't validated
- gate jackpot start in funnel

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859bf613aa0832a9b07b68f35f5b000