### PR TITLE
Disable wheel shadow by default

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -120,6 +120,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
             previewDevice={previewDevice}
             disabled={false}
             disableForm={false}
+            showShadow={true}
           />
         );
       

--- a/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
@@ -43,7 +43,7 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
   gamePosition,
   showValidationMessage,
   onWheelClick,
-  showShadow = true
+  showShadow = false
 }) => {
   const offset = shouldCropWheel && gamePosition !== 'center' 
     ? `${(containerWidth - canvasSize) / 2}px`

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -37,7 +37,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   gamePosition = 'center',
   previewDevice = 'desktop',
   disableForm = false,
-  showShadow = true
+  showShadow = false
 }) => {
   const {
     formValidated,

--- a/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
+++ b/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
@@ -102,6 +102,7 @@ const GameSwitcher: React.FC<GameSwitcherProps> = ({
           gamePosition={gamePosition}
           previewDevice={previewDevice}
           key={renderKey}
+          showShadow={true}
         />
       );
 

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -82,6 +82,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             previewDevice={previewMode}
             disabled={!formValidated}
             disableForm={true}
+            showShadow={true}
           />
         );
       


### PR DESCRIPTION
## Summary
- change WheelPreview `showShadow` default to false and propagate to WheelPreviewContent
- preserve radial shadow effect for existing usages of `WheelPreview`

## Testing
- `npm test` *(fails: tsx missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afdd9bba4832ab65e1aea9fdcae82