### PR TITLE
Fix wheel rotation using shared canvas refs

### DIFF
--- a/src/components/GameTypes/WheelComponents/WheelCanvas.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelCanvas.tsx
@@ -65,6 +65,8 @@ const WheelCanvas: React.FC<WheelCanvasProps> = ({
         canvasSize={canvasSize}
         offset={offset}
         spinning={spinning}
+        canvasRef={canvasRef}
+        shadowCanvasRef={shadowCanvasRef}
       />
     </div>
   );

--- a/src/components/GameTypes/WheelComponents/WheelPremiumRenderer.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPremiumRenderer.tsx
@@ -25,6 +25,9 @@ interface WheelPremiumRendererProps {
   borderOutlineColor?: string;
   canvasSize: number;
   spinning?: boolean;
+  /** Optional refs to allow external control over the canvas elements */
+  canvasRef?: React.RefObject<HTMLCanvasElement>;
+  shadowCanvasRef?: React.RefObject<HTMLCanvasElement>;
 }
 
 const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
@@ -36,11 +39,16 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
   customColors,
   borderColor = '#FF4444',
   canvasSize,
-  spinning = false
+  spinning = false,
+  canvasRef,
+  shadowCanvasRef
 }) => {
   const rotationRad = rotation * Math.PI / 180;
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const shadowCanvasRef = useRef<HTMLCanvasElement>(null);
+  const internalCanvasRef = useRef<HTMLCanvasElement>(null);
+  const internalShadowCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  const mainCanvasRef = canvasRef || internalCanvasRef;
+  const mainShadowCanvasRef = shadowCanvasRef || internalShadowCanvasRef;
   const [gradients, setGradients] = useState<any>(null);
   const [animationTime, setAnimationTime] = useState(0);
 
@@ -55,8 +63,8 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
   });
 
   const drawModernFortuneWheel = () => {
-    const canvas = canvasRef.current;
-    const shadowCanvas = shadowCanvasRef.current;
+    const canvas = mainCanvasRef.current;
+    const shadowCanvas = mainShadowCanvasRef.current;
     if (!canvas || !shadowCanvas || segments.length === 0) return;
     
     const ctx = canvas.getContext('2d');
@@ -331,7 +339,7 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
     <div style={{ position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
       {/* Shadow layer */}
       <canvas
-        ref={shadowCanvasRef}
+        ref={mainShadowCanvasRef}
         width={canvasSize}
         height={canvasSize}
         style={{
@@ -347,7 +355,7 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
       
       {/* Main wheel */}
       <canvas
-        ref={canvasRef}
+        ref={mainCanvasRef}
         width={canvasSize}
         height={canvasSize}
         style={{


### PR DESCRIPTION
## Summary
- allow `WheelPremiumRenderer` to receive refs for its canvas elements
- pass refs from `WheelCanvas` so `useWheelAnimations` targets the actual canvases

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685afcdc64ac832ab6e331dac1fc9010