### PR TITLE
Remove wheel shadow and allow mobile panel toggle

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -120,7 +120,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
             previewDevice={previewDevice}
             disabled={false}
             disableForm={false}
-            showShadow={true}
+            showShadow={false}
           />
         );
       

--- a/src/components/GameTypes/WheelComponents/WheelCanvas.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelCanvas.tsx
@@ -65,6 +65,8 @@ const WheelCanvas: React.FC<WheelCanvasProps> = ({
         canvasSize={canvasSize}
         offset={offset}
         spinning={spinning}
+        canvasRef={canvasRef}
+        shadowCanvasRef={shadowCanvasRef}
       />
     </div>
   );

--- a/src/components/GameTypes/WheelComponents/WheelPremiumRenderer.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPremiumRenderer.tsx
@@ -25,6 +25,9 @@ interface WheelPremiumRendererProps {
   borderOutlineColor?: string;
   canvasSize: number;
   spinning?: boolean;
+  /** Optional refs to allow external control over the canvas elements */
+  canvasRef?: React.RefObject<HTMLCanvasElement>;
+  shadowCanvasRef?: React.RefObject<HTMLCanvasElement>;
 }
 
 const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
@@ -36,11 +39,16 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
   customColors,
   borderColor = '#FF4444',
   canvasSize,
-  spinning = false
+  spinning = false,
+  canvasRef,
+  shadowCanvasRef
 }) => {
   const rotationRad = rotation * Math.PI / 180;
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const shadowCanvasRef = useRef<HTMLCanvasElement>(null);
+  const internalCanvasRef = useRef<HTMLCanvasElement>(null);
+  const internalShadowCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  const mainCanvasRef = canvasRef || internalCanvasRef;
+  const mainShadowCanvasRef = shadowCanvasRef || internalShadowCanvasRef;
   const [gradients, setGradients] = useState<any>(null);
   const [animationTime, setAnimationTime] = useState(0);
 
@@ -55,8 +63,8 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
   });
 
   const drawModernFortuneWheel = () => {
-    const canvas = canvasRef.current;
-    const shadowCanvas = shadowCanvasRef.current;
+    const canvas = mainCanvasRef.current;
+    const shadowCanvas = mainShadowCanvasRef.current;
     if (!canvas || !shadowCanvas || segments.length === 0) return;
     
     const ctx = canvas.getContext('2d');
@@ -331,7 +339,7 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
     <div style={{ position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
       {/* Shadow layer */}
       <canvas
-        ref={shadowCanvasRef}
+        ref={mainShadowCanvasRef}
         width={canvasSize}
         height={canvasSize}
         style={{
@@ -347,7 +355,7 @@ const WheelPremiumRenderer: React.FC<WheelPremiumRendererProps> = ({
       
       {/* Main wheel */}
       <canvas
-        ref={canvasRef}
+        ref={mainCanvasRef}
         width={canvasSize}
         height={canvasSize}
         style={{

--- a/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
@@ -59,20 +59,7 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
       }}
       onClick={onWheelClick}
     >
-      {showShadow && !shouldCropWheel && (
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: canvasSize + 30,
-            height: canvasSize + 30,
-            background: 'radial-gradient(circle, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.2) 60%, transparent 100%)',
-            top: '15px',
-            left: `calc(50% - ${(canvasSize + 30) / 2}px)`,
-            zIndex: 0,
-            filter: 'blur(12px)'
-          }}
-        />
-      )}
+
 
       <WheelCanvas
         segments={segments}

--- a/src/components/ModernEditor/ModernEditorLayout.tsx
+++ b/src/components/ModernEditor/ModernEditorLayout.tsx
@@ -4,6 +4,7 @@ import ModernEditorSidebar from './ModernEditorSidebar';
 import ModernEditorPanel from './ModernEditorPanel';
 import AIAssistantSidebar from './AIAssistantSidebar';
 import EditorHeader from './components/EditorHeader';
+import EditorMobilePanel from './components/EditorMobilePanel';
 import GameCanvasPreview from '../CampaignEditor/GameCanvasPreview';
 interface ModernEditorLayoutProps {
   campaign: any;
@@ -34,6 +35,7 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
 }) => {
   const [showAIAssistant] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
   const handleAIGenerate = async () => {
     setIsGenerating(true);
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -41,12 +43,12 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
   };
   return <div className="flex flex-col min-w-0 h-screen">
       {/* Header */}
-      <EditorHeader campaign={campaign} onSave={onSave} onPreview={onPreview} isLoading={isLoading} isNewCampaign={isNewCampaign} selectedDevice={previewDevice} onDeviceChange={onDeviceChange} />
+      <EditorHeader campaign={campaign} onSave={onSave} onPreview={onPreview} isLoading={isLoading} isNewCampaign={isNewCampaign} selectedDevice={previewDevice} onDeviceChange={onDeviceChange} onOpenPanel={() => setIsMobilePanelOpen(true)} />
 
       {/* Main Content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Editor Sidebar - largeur réduite de 280px à 260px */}
-        <div className="w-[390px] bg-white/95 backdrop-blur-sm border-r border-gray-200/50 shadow-sm flex-shrink-0 px-[6px] mx-0">
+        <div className="hidden md:flex w-[390px] bg-white/95 backdrop-blur-sm border-r border-gray-200/50 shadow-sm flex-shrink-0 px-[6px] mx-0">
           <div className="flex h-full">
             {/* Navigation tabs - alignés à gauche */}
             <div className="w-16 border-r border-gray-200/50 flex-shrink-0">
@@ -102,6 +104,16 @@ const ModernEditorLayout: React.FC<ModernEditorLayoutProps> = ({
           </AnimatePresence>
         </div>
       </div>
+
+      <EditorMobilePanel
+        isOpen={isMobilePanelOpen}
+        onClose={() => setIsMobilePanelOpen(false)}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        campaign={campaign}
+        setCampaign={setCampaign}
+        campaignType={campaignType as any}
+      />
     </div>;
 };
 export default ModernEditorLayout;

--- a/src/components/ModernEditor/components/EditorHeader.tsx
+++ b/src/components/ModernEditor/components/EditorHeader.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Eye, Save, Share2, MoreHorizontal } from 'lucide-react';
+import { Eye, Save, Share2, MoreHorizontal, Menu } from 'lucide-react';
 import PreviewDeviceButtons from './PreviewDeviceButtons';
 
 interface EditorHeaderProps {
@@ -11,6 +11,7 @@ interface EditorHeaderProps {
   isNewCampaign?: boolean;
   selectedDevice?: 'desktop' | 'tablet' | 'mobile';
   onDeviceChange?: (device: 'desktop' | 'tablet' | 'mobile') => void;
+  onOpenPanel?: () => void;
 }
 
 const EditorHeader: React.FC<EditorHeaderProps> = ({
@@ -20,7 +21,8 @@ const EditorHeader: React.FC<EditorHeaderProps> = ({
   isLoading = false,
   isNewCampaign = false,
   selectedDevice = 'desktop',
-  onDeviceChange = () => {}
+  onDeviceChange = () => {},
+  onOpenPanel
 }) => {
   return (
     <div className="bg-white/95 backdrop-blur-sm border-b border-gray-100 flex-shrink-0 z-50">
@@ -28,6 +30,14 @@ const EditorHeader: React.FC<EditorHeaderProps> = ({
         <div className="flex items-center justify-between">
           {/* Left section - Titre de la campagne */}
           <div className="flex items-center space-x-4 flex-shrink-0">
+            {onOpenPanel && (
+              <button
+                onClick={onOpenPanel}
+                className="md:hidden p-2 hover:bg-gray-100 rounded-lg"
+              >
+                <Menu className="w-5 h-5" />
+              </button>
+            )}
             <div className="flex-1 min-w-0">
               <h1 className="text-xl font-bold text-gray-900 truncate">
                 {campaign.name || (isNewCampaign ? 'Nouvelle Campagne' : 'Campagne')}

--- a/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
+++ b/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
@@ -102,7 +102,7 @@ const GameSwitcher: React.FC<GameSwitcherProps> = ({
           gamePosition={gamePosition}
           previewDevice={previewDevice}
           key={renderKey}
-          showShadow={true}
+          showShadow={false}
         />
       );
 

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -82,7 +82,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             previewDevice={previewMode}
             disabled={!formValidated}
             disableForm={true}
-            showShadow={true}
+            showShadow={false}
           />
         );
       


### PR DESCRIPTION
## Summary
- disable wheel shadow in all previews and remove shadow element
- support opening settings panel on mobile devices
- add menu button in `EditorHeader` to toggle `EditorMobilePanel`

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685afcdc64ac832ab6e331dac1fc9010