### PR TITLE
Remove wheel shadow overlay

### DIFF
--- a/src/components/CampaignEditor/GameCanvasPreview.tsx
+++ b/src/components/CampaignEditor/GameCanvasPreview.tsx
@@ -120,7 +120,7 @@ const GameCanvasPreview: React.FC<GameCanvasPreviewProps> = ({
             previewDevice={previewDevice}
             disabled={false}
             disableForm={false}
-            showShadow={true}
+            showShadow={false}
           />
         );
       

--- a/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
+++ b/src/components/GameTypes/WheelComponents/WheelPreviewContent.tsx
@@ -59,20 +59,7 @@ const WheelPreviewContent: React.FC<WheelPreviewContentProps> = ({
       }}
       onClick={onWheelClick}
     >
-      {showShadow && !shouldCropWheel && (
-        <div
-          className="absolute rounded-full"
-          style={{
-            width: canvasSize + 30,
-            height: canvasSize + 30,
-            background: 'radial-gradient(circle, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.2) 60%, transparent 100%)',
-            top: '15px',
-            left: `calc(50% - ${(canvasSize + 30) / 2}px)`,
-            zIndex: 0,
-            filter: 'blur(12px)'
-          }}
-        />
-      )}
+
 
       <WheelCanvas
         segments={segments}

--- a/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
+++ b/src/components/QuickCampaign/Preview/components/GameSwitcher.tsx
@@ -102,7 +102,7 @@ const GameSwitcher: React.FC<GameSwitcherProps> = ({
           gamePosition={gamePosition}
           previewDevice={previewDevice}
           key={renderKey}
-          showShadow={true}
+          showShadow={false}
         />
       );
 

--- a/src/components/funnels/components/GameRenderer.tsx
+++ b/src/components/funnels/components/GameRenderer.tsx
@@ -82,7 +82,7 @@ const GameRenderer: React.FC<GameRendererProps> = ({
             previewDevice={previewMode}
             disabled={!formValidated}
             disableForm={true}
-            showShadow={true}
+            showShadow={false}
           />
         );
       


### PR DESCRIPTION
## Summary
- drop radial gradient overlay from `WheelPreviewContent`
- disable the wheel shadow option in `GameRenderer`, `GameCanvasPreview`, and `GameSwitcher`

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b39b9bf7c832a86e306aa99d6bdec