### PR TITLE
Adjust DeviceFrame scrolling

### DIFF
--- a/src/components/QualifioEditor/Preview/DeviceFrame.tsx
+++ b/src/components/QualifioEditor/Preview/DeviceFrame.tsx
@@ -17,7 +17,7 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
           margin: '20px auto',
           border: '8px solid #333',
           borderRadius: '25px',
-          overflow: 'hidden'
+          overflowY: 'auto'
         };
       case 'tablet':
         return {
@@ -26,7 +26,7 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
           margin: '20px auto',
           border: '12px solid #333',
           borderRadius: '20px',
-          overflow: 'hidden'
+          overflowY: 'auto'
         };
       case 'desktop':
       default:
@@ -55,7 +55,7 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
         {device === 'mobile' || device === 'tablet' ? <div className="scrollbar-hide" style={{
         width: '100%',
         height: '100%',
-        overflow: 'hidden',
+        overflowY: 'auto',
         position: 'relative'
       }}>
             {children}


### PR DESCRIPTION
## Summary
- allow vertical scrolling in the mobile and tablet preview frames
- keep desktop preview behavior unchanged

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876ab6bf448832aaf0cf61049120494