### PR TITLE
Fix game centering

### DIFF
--- a/src/components/QualifioEditor/Preview/GameRenderer.tsx
+++ b/src/components/QualifioEditor/Preview/GameRenderer.tsx
@@ -50,13 +50,17 @@ const GameRenderer: React.FC<GameRendererProps> = ({
     };
 
     return {
-      transform: `translate(${gamePosition.x}%, ${gamePosition.y}%)`,
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: `translate(-50%, -50%) translate(${gamePosition.x}%, ${gamePosition.y}%)`,
       transformOrigin: 'center center',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
       width: '100%',
       height: '100%',
+      overflow: 'hidden',
       minHeight: getMinHeight(),
       padding: getPadding(),
       boxSizing: 'border-box',


### PR DESCRIPTION
## Summary
- center game container absolutely in the preview
- keep wheel centered and hide overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876b38ccc88832a997b3a990bc9ca90