### PR TITLE
Reduce Qualifio editor preview size on desktop

### DIFF
--- a/src/components/QualifioEditor/Preview/DeviceFrame.tsx
+++ b/src/components/QualifioEditor/Preview/DeviceFrame.tsx
@@ -7,6 +7,7 @@ interface DeviceFrameProps {
 }
 const DeviceFrame: React.FC<DeviceFrameProps> = ({ device, children }) => {
   const { maxWidth, maxHeight } = DEVICE_CONSTRAINTS[device];
+  const scaleFactor = device === "desktop" ? 0.9 : 1;
 
   const getFrameBorders = () => {
     switch (device) {
@@ -21,8 +22,8 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({ device, children }) => {
   };
 
   const frameStyles: React.CSSProperties = {
-    width: Math.min(maxWidth, window.innerWidth),
-    height: Math.min(maxHeight, window.innerHeight),
+    width: Math.min(maxWidth, window.innerWidth) * scaleFactor,
+    height: Math.min(maxHeight, window.innerHeight) * scaleFactor,
     ...getFrameBorders(),
     overflow: "hidden",
   };


### PR DESCRIPTION
## Summary
- apply a scaling factor to the Qualifio editor preview frame when the selected device is desktop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876b8041f18832a97ca80f70474eb1e