### PR TITLE
Make Qualifio editor responsive

### DIFF
--- a/src/components/QualifioEditor/Preview/DeviceFrame.tsx
+++ b/src/components/QualifioEditor/Preview/DeviceFrame.tsx
@@ -18,8 +18,9 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
     switch (device) {
       case 'mobile':
         return {
-          width: '350px',
-          height: '622px',
+          width: '100%',
+          maxWidth: '350px',
+          minHeight: '622px',
           margin: '20px auto',
           border: '8px solid #333',
           borderRadius: '25px',
@@ -27,8 +28,9 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
         };
       case 'tablet':
         return {
-          width: '653px',
-          height: '720px',
+          width: '100%',
+          maxWidth: '653px',
+          minHeight: '720px',
           margin: '20px auto',
           border: '12px solid #333',
           borderRadius: '20px',
@@ -38,7 +40,8 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
       default:
         if (fitContentDesktop) {
           return {
-            width: '1020px',
+            width: '100%',
+            maxWidth: '1020px',
             margin: '20px auto',
             border: '2px solid #ddd',
             borderRadius: '8px',
@@ -46,8 +49,9 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
           };
         }
         return {
-          width: '1020px',
-          height: '680px',
+          width: '100%',
+          maxWidth: '1020px',
+          minHeight: '680px',
           // Hauteur fixe pour que l'image de fond remplisse complètement
           margin: '20px auto',
           border: '2px solid #ddd',

--- a/src/components/QualifioEditor/QualifioEditorLayout.tsx
+++ b/src/components/QualifioEditor/QualifioEditorLayout.tsx
@@ -195,7 +195,7 @@ const QualifioEditorLayout: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-brand-accent">
+    <div className="min-h-screen bg-brand-accent flex flex-col">
       {/* Header avec couleurs de marque */}
       <div className="bg-white border-b border-gray-200 px-6 py-4">
         <div className="flex items-center justify-between">
@@ -229,15 +229,15 @@ const QualifioEditorLayout: React.FC = () => {
       </div>
 
       {/* Main Content */}
-      <div className="flex">
+      <div className="flex flex-col lg:flex-row">
         {/* Sidebar */}
-        <QualifioSidebar 
+        <QualifioSidebar
           config={config}
           onConfigUpdate={updateConfig}
         />
         
         {/* Preview Area */}
-        <div className="flex-1 p-6">
+        <div className="flex-1 p-4 sm:p-6 w-full">
           <QualifioPreview 
             device={selectedDevice}
             config={config}

--- a/src/components/QualifioEditor/QualifioSidebar.tsx
+++ b/src/components/QualifioEditor/QualifioSidebar.tsx
@@ -74,7 +74,7 @@ const QualifioSidebar: React.FC<QualifioSidebarProps> = ({
         return null;
     }
   };
-  return <div className="w-96 sidebar-premium flex flex-col h-screen">
+  return <div className="w-full lg:w-96 sidebar-premium flex flex-col h-auto lg:h-screen">
       {/* Header élégant blanc avec accents violets */}
       
 


### PR DESCRIPTION
## Summary
- improve responsive design of `/qualifio-editor`
- adjust sidebar and layout for mobile
- use flexible widths for device frame

## Testing
- `npm test` *(fails: Dependency `tsx` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_687955e7f0ec832a98f8e18528635a71