### PR TITLE
Add dynamic wheel segments

### DIFF
--- a/src/components/QualifioEditor/Preview/WheelContainer.tsx
+++ b/src/components/QualifioEditor/Preview/WheelContainer.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { SmartWheel } from '../../SmartWheel';
 import type { DeviceType, EditorConfig } from '../QualifioEditorLayout';
+import { createSegments } from './wheelHelpers';
 
 interface WheelContainerProps {
   device: DeviceType;
@@ -20,19 +21,16 @@ const WheelContainer: React.FC<WheelContainerProps> = ({
   onResult,
   scale = 1.0
 }) => {
+  const brandColor = config.brandAssets?.primaryColor || '#4ECDC4';
+
   // Utiliser les couleurs extraites de l'image si disponibles
   const brandColors = config.brandAssets ? {
-    primary: config.brandAssets.primaryColor || '#4ECDC4',
-    secondary: config.brandAssets.secondaryColor || '#F7B731', 
+    primary: brandColor,
+    secondary: config.brandAssets.secondaryColor || '#F7B731',
     accent: config.brandAssets.accentColor || '#E74C3C'
   } : undefined;
 
-  const wheelSegments = [
-    { id: '1', label: 'Prix 3', color: brandColors?.accent || '#4ECDC4' },
-    { id: '2', label: 'Dommage', color: brandColors?.secondary || '#F7B731' },
-    { id: '3', label: 'Prix 1', color: brandColors?.primary || '#E74C3C' },
-    { id: '4', label: 'Prix 2', color: brandColors?.primary || '#26D0CE' }
-  ];
+  const wheelSegments = createSegments(config, brandColor);
 
   const handleWheelResult = (segment: any) => {
     console.log('Segment sélectionné:', segment);

--- a/src/components/QualifioEditor/Preview/wheelHelpers.ts
+++ b/src/components/QualifioEditor/Preview/wheelHelpers.ts
@@ -1,0 +1,26 @@
+import type { EditorConfig } from '../QualifioEditorLayout';
+import { DEFAULT_WHEEL_SEGMENTS } from '../../../utils/wheelConfig';
+
+export interface WheelSegment {
+  id: string;
+  label: string;
+  color: string;
+}
+
+export const createSegments = (
+  config: EditorConfig,
+  brandColor: string
+): WheelSegment[] => {
+  const defaultLabels = DEFAULT_WHEEL_SEGMENTS.map(s => s.label);
+  const labels = (config.wheelSegments?.map((s: any) => s.label) || defaultLabels).slice();
+
+  if (labels.length % 2 !== 0) {
+    labels.push(defaultLabels[labels.length % defaultLabels.length] || `Segment ${labels.length + 1}`);
+  }
+
+  return labels.map((label, idx) => ({
+    id: String(idx + 1),
+    label,
+    color: idx % 2 === 0 ? brandColor : '#ffffff'
+  }));
+};

--- a/test/createSegments.test.ts
+++ b/test/createSegments.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSegments } from '../src/components/QualifioEditor/Preview/wheelHelpers';
+
+const baseConfig: any = { wheelSegments: [{ label: 'A' }, { label: 'B' }, { label: 'C' }] };
+
+const brandColor = '#123456';
+
+test('createSegments returns even count', () => {
+  const result = createSegments(baseConfig, brandColor);
+  assert.equal(result.length % 2, 0);
+});
+
+test('createSegments alternates colors starting with brandColor', () => {
+  const result = createSegments(baseConfig, brandColor);
+  result.forEach((seg, idx) => {
+    const expected = idx % 2 === 0 ? brandColor : '#ffffff';
+    assert.equal(seg.color, expected);
+  });
+});


### PR DESCRIPTION
## Summary
- compute brandColor based on config data
- add helper for building wheel segments
- generate wheel segments in WheelContainer
- test the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687962162d44832aba626d06b939692c