### PR TITLE
Add option to reuse desktop background

### DIFF
--- a/src/components/QualifioEditor/SidebarTabs/GameZoneTab.tsx
+++ b/src/components/QualifioEditor/SidebarTabs/GameZoneTab.tsx
@@ -12,6 +12,8 @@ const GameZoneTab: React.FC<GameZoneTabProps> = ({
   onConfigUpdate
 }) => {
   const [selectedDevice, setSelectedDevice] = useState<DeviceType>('desktop');
+  const [applyToTablet, setApplyToTablet] = useState(false);
+  const [applyToMobile, setApplyToMobile] = useState(false);
   
   // Créer des refs séparés pour chaque device
   const desktopInputRef = useRef<HTMLInputElement>(null);
@@ -34,23 +36,65 @@ const GameZoneTab: React.FC<GameZoneTabProps> = ({
     inputRef.current?.click();
   };
 
+  const applyDesktopImageTo = (target: 'tablet' | 'mobile') => {
+    const imageUrl = config.deviceConfig?.desktop?.backgroundImage;
+    if (!imageUrl) return;
+    onConfigUpdate({
+      deviceConfig: {
+        mobile: config.deviceConfig?.mobile || { fontSize: 14 },
+        tablet: config.deviceConfig?.tablet || { fontSize: 16 },
+        desktop: config.deviceConfig?.desktop || { fontSize: 18 },
+        [target]: {
+          ...config.deviceConfig?.[target],
+          backgroundImage: imageUrl
+        }
+      }
+    });
+  };
+
+  const handleApplyToggle = (target: 'tablet' | 'mobile', checked: boolean) => {
+    if (target === 'tablet') {
+      setApplyToTablet(checked);
+    } else {
+      setApplyToMobile(checked);
+    }
+    if (checked) {
+      applyDesktopImageTo(target);
+    }
+  };
+
   const handleBackgroundImageUpload = async (device: DeviceType, file: File) => {
     console.log('handleBackgroundImageUpload called for:', device, 'with file:', file);
     
     if (!file || file.size === 0) {
       console.log('No file or empty file, removing image for:', device);
-      // Supprimer l'image si fichier vide
-      onConfigUpdate({
-        deviceConfig: {
-          mobile: config.deviceConfig?.mobile || { fontSize: 14 },
-          tablet: config.deviceConfig?.tablet || { fontSize: 16 },
-          desktop: config.deviceConfig?.desktop || { fontSize: 18 },
-          [device]: {
-            ...config.deviceConfig?.[device],
-            backgroundImage: undefined
-          }
+      const baseDeviceConfig = {
+        mobile: config.deviceConfig?.mobile || { fontSize: 14 },
+        tablet: config.deviceConfig?.tablet || { fontSize: 16 },
+        desktop: config.deviceConfig?.desktop || { fontSize: 18 }
+      };
+      const newDeviceConfig: any = {
+        ...baseDeviceConfig,
+        [device]: {
+          ...config.deviceConfig?.[device],
+          backgroundImage: undefined
         }
-      });
+      };
+      if (device === 'desktop') {
+        if (applyToTablet) {
+          newDeviceConfig.tablet = {
+            ...newDeviceConfig.tablet,
+            backgroundImage: undefined
+          };
+        }
+        if (applyToMobile) {
+          newDeviceConfig.mobile = {
+            ...newDeviceConfig.mobile,
+            backgroundImage: undefined
+          };
+        }
+      }
+      onConfigUpdate({ deviceConfig: newDeviceConfig });
       return;
     }
 
@@ -64,16 +108,35 @@ const GameZoneTab: React.FC<GameZoneTabProps> = ({
         // Extract colors from background image
         const brandTheme = await generateBrandThemeFromFile(file);
         
-        const newConfig = {
-          deviceConfig: {
-            mobile: config.deviceConfig?.mobile || { fontSize: 14 },
-            tablet: config.deviceConfig?.tablet || { fontSize: 16 },
-            desktop: config.deviceConfig?.desktop || { fontSize: 18 },
-            [device]: {
-              ...config.deviceConfig?.[device],
+        const baseDeviceConfig = {
+          mobile: config.deviceConfig?.mobile || { fontSize: 14 },
+          tablet: config.deviceConfig?.tablet || { fontSize: 16 },
+          desktop: config.deviceConfig?.desktop || { fontSize: 18 }
+        };
+        const newDeviceConfig: any = {
+          ...baseDeviceConfig,
+          [device]: {
+            ...config.deviceConfig?.[device],
+            backgroundImage: imageUrl
+          }
+        };
+        if (device === 'desktop') {
+          if (applyToTablet) {
+            newDeviceConfig.tablet = {
+              ...newDeviceConfig.tablet,
               backgroundImage: imageUrl
-            }
-          },
+            };
+          }
+          if (applyToMobile) {
+            newDeviceConfig.mobile = {
+              ...newDeviceConfig.mobile,
+              backgroundImage: imageUrl
+            };
+          }
+        }
+
+        const newConfig = {
+          deviceConfig: newDeviceConfig,
           // Update brand assets with extracted colors
           brandAssets: {
             ...config.brandAssets,
@@ -88,16 +151,34 @@ const GameZoneTab: React.FC<GameZoneTabProps> = ({
       } catch (error) {
         console.error('Error extracting colors from background image:', error);
         // Fallback: just update the image without color extraction
-        const newConfig = {
-          deviceConfig: {
-            mobile: config.deviceConfig?.mobile || { fontSize: 14 },
-            tablet: config.deviceConfig?.tablet || { fontSize: 16 },
-            desktop: config.deviceConfig?.desktop || { fontSize: 18 },
-            [device]: {
-              ...config.deviceConfig?.[device],
-              backgroundImage: imageUrl
-            }
+        const baseDeviceConfig = {
+          mobile: config.deviceConfig?.mobile || { fontSize: 14 },
+          tablet: config.deviceConfig?.tablet || { fontSize: 16 },
+          desktop: config.deviceConfig?.desktop || { fontSize: 18 }
+        };
+        const newDeviceConfig: any = {
+          ...baseDeviceConfig,
+          [device]: {
+            ...config.deviceConfig?.[device],
+            backgroundImage: imageUrl
           }
+        };
+        if (device === 'desktop') {
+          if (applyToTablet) {
+            newDeviceConfig.tablet = {
+              ...newDeviceConfig.tablet,
+              backgroundImage: imageUrl
+            };
+          }
+          if (applyToMobile) {
+            newDeviceConfig.mobile = {
+              ...newDeviceConfig.mobile,
+              backgroundImage: imageUrl
+            };
+          }
+        }
+        const newConfig = {
+          deviceConfig: newDeviceConfig
         };
         onConfigUpdate(newConfig);
       }
@@ -202,15 +283,36 @@ const GameZoneTab: React.FC<GameZoneTabProps> = ({
             />
             
             {/* Bouton de sélection visible */}
-            <button 
+            <button
               type="button"
               onClick={() => triggerFileSelect(selectedDevice)}
-              className="flex items-center justify-center gap-2 p-4 border-2 border-dashed rounded-xl cursor-pointer hover:border-sidebar-active transition-colors w-full" 
+              className="flex items-center justify-center gap-2 p-4 border-2 border-dashed rounded-xl cursor-pointer hover:border-sidebar-active transition-colors w-full"
               style={{ borderColor: 'hsl(var(--sidebar-border))' }}
             >
               <Upload className="w-5 h-5" />
               <span>Choisir une image ({selectedDevice})</span>
             </button>
+
+            {selectedDevice === 'desktop' && (
+              <div className="flex gap-4 text-xs">
+                <label className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={applyToTablet}
+                    onChange={(e) => handleApplyToggle('tablet', e.target.checked)}
+                  />
+                  Utiliser sur tablette
+                </label>
+                <label className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={applyToMobile}
+                    onChange={(e) => handleApplyToggle('mobile', e.target.checked)}
+                  />
+                  Utiliser sur mobile
+                </label>
+              </div>
+            )}
             
             {/* Aperçu de l'image */}
             {currentDeviceConfig?.backgroundImage && (


### PR DESCRIPTION
## Summary
- add checkboxes under Game Zone device selector for applying desktop image to tablet and/or mobile
- update background image handler to replicate or remove images across devices when checkboxes are checked

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68798783538c832a959ac9f9ec858d55