### PR TITLE
Implement live preview for Qualifio editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import AdminSettings from './pages/AdminSettings';
 import AdminTeam from './pages/AdminTeam';
 import AdminAlerts from './pages/AdminAlerts';
 import QualifioEditor from './pages/QualifioEditor';
+import QualifioLivePreview from './pages/QualifioLivePreview';
 
 function App() {
   return (
@@ -87,6 +88,7 @@ function App() {
             } />
             
             <Route path="/qualifio-editor" element={<QualifioEditor />} />
+            <Route path="/qualifio-live" element={<QualifioLivePreview />} />
             
             <Route path="/admin" element={<AdminLayout />}>
               <Route index element={<Admin />} />

--- a/src/components/QualifioEditor/QualifioEditorLayout.tsx
+++ b/src/components/QualifioEditor/QualifioEditorLayout.tsx
@@ -220,8 +220,14 @@ const QualifioEditorLayout: React.FC = () => {
               onDeviceChange={setSelectedDevice}
             />
             <div className="flex gap-2">
-              <button className="px-4 py-2 bg-brand-accent text-brand-primary rounded-lg hover:bg-brand-accent/80 transition-colors">
-                Sauvegarder le template
+              <button
+                onClick={() => {
+                  localStorage.setItem('qualifio_live_preview_config', JSON.stringify(config));
+                  window.open(`/qualifio-live?device=${selectedDevice}`, '_blank');
+                }}
+                className="px-4 py-2 bg-brand-accent text-brand-primary rounded-lg hover:bg-brand-accent/80 transition-colors"
+              >
+                Aperçu live
               </button>
               <button className="px-4 py-2 bg-brand-primary text-white rounded-lg hover:bg-brand-primary/90 transition-colors flex items-center gap-2">
                 <Save className="w-4 h-4" />

--- a/src/pages/QualifioLivePreview.tsx
+++ b/src/pages/QualifioLivePreview.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import QualifioPreview from '../components/QualifioEditor/QualifioPreview';
+import type { DeviceType, EditorConfig } from '../components/QualifioEditor/QualifioEditorLayout';
+
+const QualifioLivePreview: React.FC = () => {
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const device = (query.get('device') as DeviceType) || 'desktop';
+
+  const [config, setConfig] = useState<EditorConfig | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('qualifio_live_preview_config');
+    if (stored) {
+      setConfig(JSON.parse(stored));
+    }
+  }, []);
+
+  if (!config) return null;
+
+  return (
+    <div className="bg-gray-100 min-h-screen">
+      <QualifioPreview device={device} config={config} />
+    </div>
+  );
+};
+
+export default QualifioLivePreview;


### PR DESCRIPTION
## Summary
- add a new `QualifioLivePreview` page
- expose it under `/qualifio-live`
- replace the **Sauvegarder le template** button with **Aperçu live** in the Qualifio editor

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6879b8fdcd30832aab787b9629f06637