### PR TITLE
Handle missing config in live preview

### DIFF
--- a/src/pages/QualifioLivePreview.tsx
+++ b/src/pages/QualifioLivePreview.tsx
@@ -9,13 +9,26 @@ const QualifioLivePreview: React.FC = () => {
   const device = (query.get('device') as DeviceType) || 'desktop';
 
   const [config, setConfig] = useState<EditorConfig | null>(null);
+  const [loadingError, setLoadingError] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('qualifio_live_preview_config');
     if (stored) {
       setConfig(JSON.parse(stored));
+    } else {
+      setLoadingError(true);
     }
   }, []);
+
+  if (loadingError) {
+    return (
+      <div className="bg-gray-100 min-h-screen flex items-center justify-center">
+        <p className="text-gray-500 text-center p-4">
+          L&apos;aperçu live doit être ouvert depuis l&apos;éditeur.
+        </p>
+      </div>
+    );
+  }
 
   if (!config) return null;
 


### PR DESCRIPTION
## Summary
- show helpful message if live preview is opened directly

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a088d695c832a850c5a68bc9de6e5