### PR TITLE
Fix background fill on Qualifio mobile/tablet preview

### DIFF
--- a/src/components/QualifioEditor/Preview/DeviceFrame.tsx
+++ b/src/components/QualifioEditor/Preview/DeviceFrame.tsx
@@ -127,16 +127,19 @@ const DeviceFrame: React.FC<DeviceFrameProps> = ({
         {device === 'mobile' || device === 'tablet' ? (
           <>
             {/* Container pour l'image de fond - s'étend sur tout le device */}
-            <div style={{
-              position: 'absolute' as const,
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              borderRadius: device === 'mobile' ? '25px' : '20px',
-              overflow: 'hidden' as const,
-              zIndex: 1
-            }}>
+            <div
+              className="w-full h-full"
+              style={{
+                position: 'absolute' as const,
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                borderRadius: device === 'mobile' ? '25px' : '20px',
+                overflow: 'hidden' as const,
+                zIndex: 1
+              }}
+            >
               {children}
             </div>
             

--- a/src/components/QualifioEditor/Preview/Mode2Preview.tsx
+++ b/src/components/QualifioEditor/Preview/Mode2Preview.tsx
@@ -51,7 +51,7 @@ const Mode2Preview: React.FC<Mode2PreviewProps> = ({
         device={device}
         config={config}
         onClick={handleContainerClick}
-        className="overflow-hidden relative"
+        className="w-full h-full overflow-hidden relative"
       >
         {/* Boutons positionnés en haut de la zone d'aperçu, en dessous de la barre de statut */}
         <motion.div 


### PR DESCRIPTION
## Summary
- ensure background container stretches fully in Mode2 mobile/tablet preview
- set mobile/tablet container to full width and height in DeviceFrame

## Testing
- `npm ci` *(fails: missing dependencies)*
- `npm test --silent` *(fails: dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e7ce79248832a858f68286e9cb7fd