### PR TITLE
Replace campaign-editor paths with design-editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
               </EditorOnlyLayout>
             } />
             
-            <Route path="/campaign-editor" element={<GameEditor />} />
+            <Route path="/design-editor" element={<GameEditor />} />
             <Route path="/design-editor" element={<DesignEditor />} />
             <Route path="/live-preview" element={<LivePreview />} />
             

--- a/src/components/QuickCampaign/Step4Finalization.tsx
+++ b/src/components/QuickCampaign/Step4Finalization.tsx
@@ -99,7 +99,7 @@ const Step4Finalization: React.FC = () => {
       console.log('Editor config created:', editorConfig);
       
       // Navigate to campaign editor
-      navigate('/campaign-editor');
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/QuickCampaign/Studio/StudioPreview.tsx
+++ b/src/components/QuickCampaign/Studio/StudioPreview.tsx
@@ -149,7 +149,7 @@ const StudioPreview: React.FC<StudioPreviewProps> = ({
       console.log('Transferring Studio data:', { fullCampaignData, editorConfig });
       
       // Naviguer vers l'éditeur avec rechargement forcé
-      window.location.href = '/campaign-editor';
+      window.location.href = '/design-editor';
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/funnels/components/ResultScreen.tsx
+++ b/src/components/funnels/components/ResultScreen.tsx
@@ -88,7 +88,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({
       localStorage.setItem('campaignPreview', JSON.stringify(campaign));
       localStorage.setItem('editorConfig', JSON.stringify(editorConfig));
       
-      navigate('/campaign-editor');
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -188,7 +188,7 @@ const Campaigns: React.FC = () => {
               Création rapide
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -71,14 +71,14 @@ const Gamification: React.FC = () => {
         actions={
           <div className="flex gap-x-4">
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
               Éditeur de Jeux
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
@@ -112,7 +112,7 @@ const Gamification: React.FC = () => {
                     <h3 className="font-bold text-gray-800 mb-1">{game.name}</h3>
                     <p className="text-sm text-gray-600 mb-4">{game.description}</p>
                     <Link
-                      to="/campaign-editor"
+                      to="/design-editor"
                       className="w-full px-4 py-2 bg-gray-100 text-gray-800 font-medium rounded-lg hover:bg-gray-200 transition-colors duration-200 block text-center"
                     >
                       Créer avec l'éditeur


### PR DESCRIPTION
## Summary
- replace /campaign-editor routing with /design-editor across app

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: connect ENETUNREACH to github, nvcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b60e71a4832a94f933a686d158c1