### PR TITLE
Fix mobile tab interaction in design editor

### DIFF
--- a/src/components/DesignEditor/HybridSidebar.tsx
+++ b/src/components/DesignEditor/HybridSidebar.tsx
@@ -335,10 +335,11 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
                   console.log('🗂️ Événement touchStart sur bouton onglet:', tab.id);
                   e.preventDefault();
                   e.stopPropagation();
+                  handleTabClick(tab.id);
                 }}
                 className={`p-4 flex flex-col items-center justify-center border-b border-[hsl(var(--sidebar-border))] transition-all duration-200 cursor-pointer ${
-                  isActive 
-                    ? 'bg-[hsl(var(--sidebar-active-bg))] text-[hsl(var(--sidebar-icon-active))] border-r-2 border-r-[hsl(var(--sidebar-active))] shadow-sm' 
+                  isActive
+                    ? 'bg-[hsl(var(--sidebar-active-bg))] text-[hsl(var(--sidebar-icon-active))] border-r-2 border-r-[hsl(var(--sidebar-active))] shadow-sm'
                     : 'text-[hsl(var(--sidebar-icon))] hover:bg-[hsl(var(--sidebar-hover))] hover:text-[hsl(var(--sidebar-icon-active))]'
                 }`}
                 title={tab.label}


### PR DESCRIPTION
## Summary
- Ensure design editor tabs respond to touch by invoking `handleTabClick` on touch events

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.114.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_6895e24fa494832aa9885814a3c51507