### PR TITLE
Ensure wheel preview uses unified config

### DIFF
--- a/src/components/DesignEditor/DesignCanvas.tsx
+++ b/src/components/DesignEditor/DesignCanvas.tsx
@@ -17,7 +17,6 @@ import { useAdaptiveAutoSave } from '../ModernEditor/hooks/useAdaptiveAutoSave';
 import { useUltraFluidDragDrop } from '../ModernEditor/hooks/useUltraFluidDragDrop';
 import { useVirtualizedCanvas } from '../ModernEditor/hooks/useVirtualizedCanvas';
 import { useEditorStore } from '../../stores/editorStore';
-import { useWheelConfigSync } from '../../hooks/useWheelConfigSync';
 import CanvasContextMenu from './components/CanvasContextMenu';
 
 import AnimationSettingsPopup from './panels/AnimationSettingsPopup';
@@ -61,9 +60,11 @@ export interface DesignCanvasProps {
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
+  updateWheelConfig?: (updates: any) => void;
+  getCanonicalConfig?: (options?: { device?: string; shouldCropWheel?: boolean }) => any;
 }
 
-const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
+const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({ 
   selectedDevice,
   elements,
   onElementsChange,
@@ -95,7 +96,9 @@ const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
   onUndo,
   onRedo,
   canUndo,
-  canRedo
+  canRedo,
+  updateWheelConfig,
+  getCanonicalConfig
 }, ref) => {
 
   const canvasRef = useRef<HTMLDivElement>(null);
@@ -341,12 +344,7 @@ const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
     return { x: absoluteX, y: absoluteY };
   }, [elements]);
 
-  // Hook de synchronisation unifié pour la roue
-  const { updateWheelConfig, getCanonicalConfig } = useWheelConfigSync({
-    campaign,
-    extractedColors: campaign?.design?.brandColors ? Object.values(campaign.design.brandColors) : [],
-    onCampaignChange
-  });
+  // Les fonctions de configuration de la roue sont maintenant fournies par le composant parent
 
   // Écouteur d'événement pour l'application des effets de texte depuis le panneau latéral
   useEffect(() => {
@@ -485,8 +483,10 @@ const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
   });
 
   // Configuration canonique de la roue
-  const wheelConfig = useMemo(() => 
-    getCanonicalConfig({ device: selectedDevice, shouldCropWheel: true }),
+  const wheelConfig = useMemo(() =>
+    getCanonicalConfig
+      ? getCanonicalConfig({ device: selectedDevice, shouldCropWheel: true })
+      : { borderStyle: 'classic', borderColor: '#841b60', borderWidth: 12, scale: 1 },
     [getCanonicalConfig, selectedDevice]
   );
 
@@ -980,11 +980,11 @@ const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
           wheelScale={wheelConfig.scale}
           wheelShowBulbs={!!wheelConfig.showBulbs}
 
-          onBorderStyleChange={(style) => updateWheelConfig({ borderStyle: style })}
-          onBorderColorChange={(color) => updateWheelConfig({ borderColor: color })}
-          onBorderWidthChange={(width) => updateWheelConfig({ borderWidth: width })}
-          onScaleChange={(scale) => updateWheelConfig({ scale })}
-          onShowBulbsChange={(show) => updateWheelConfig({ showBulbs: show })}
+          onBorderStyleChange={(style) => updateWheelConfig?.({ borderStyle: style })}
+          onBorderColorChange={(color) => updateWheelConfig?.({ borderColor: color })}
+          onBorderWidthChange={(width) => updateWheelConfig?.({ borderWidth: width })}
+          onScaleChange={(scale) => updateWheelConfig?.({ scale })}
+          onShowBulbsChange={(show) => updateWheelConfig?.({ showBulbs: show })}
 
           selectedDevice={selectedDevice}
         />

--- a/src/components/DesignEditor/DesignEditorLayout.tsx
+++ b/src/components/DesignEditor/DesignEditorLayout.tsx
@@ -169,7 +169,11 @@ const DesignEditorLayout: React.FC = () => {
   };
 
   // Utilisation du hook de synchronisation unifié
-  const { wheelModalConfig } = useWheelConfigSync({
+  const {
+    wheelModalConfig,
+    updateWheelConfig,
+    getCanonicalConfig
+  } = useWheelConfigSync({
     campaign: campaignConfig,
     extractedColors,
     onCampaignChange: setCampaignConfig
@@ -697,6 +701,8 @@ const DesignEditorLayout: React.FC = () => {
               selectedElements={selectedElements}
               onSelectedElementsChange={setSelectedElements}
               onElementUpdate={handleElementUpdate}
+              updateWheelConfig={updateWheelConfig}
+              getCanonicalConfig={getCanonicalConfig}
               // Props pour le système de groupes niveau Canva
               selectedGroupId={selectedGroupId || undefined}
               onSelectedGroupChange={setSelectedGroupId}


### PR DESCRIPTION
## Summary
- fix design editor preview to use canonical wheel configuration
- expose wheel configuration handlers from layout to canvas for real-time sync

## Testing
- `npm test` *(fails: missing dependencies)*
- `npm ci` *(fails: connect ENETUNREACH to GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_6896a51f1984832a9a6a81a2ddf39481