### PR TITLE
Adjust mobile margins for layout

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -47,7 +47,7 @@ const Layout: React.FC = () => {
           <img src={logo} alt="Prosplay Logo" className="h-8 w-auto" />
         </header>
         <main className="flex-1 overflow-y-auto w-full py-0 px-0">
-          <div className="p-3 sm:p-6 w-full max-w-full py-0 px-[3px]">
+          <div className="w-full max-w-full py-0 sm:py-6 px-4 sm:px-6">
             <Outlet />
           </div>
         </main>


### PR DESCRIPTION
## Summary
- increase horizontal padding on mobile layout to prevent edge-to-edge content
- maintain desktop vertical padding while applying new mobile margin

## Testing
- `npm ci` *(fails: connect ENETUNREACH when downloading dependencies)*
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896ad8ad578832a89a41c3ee5a31d7e