### PR TITLE
Remove duplicate device selector on mobile preview

### DIFF
--- a/src/components/QuickCampaign/CampaignPreviewModal.tsx
+++ b/src/components/QuickCampaign/CampaignPreviewModal.tsx
@@ -14,7 +14,7 @@ const CampaignPreviewModal: React.FC<CampaignPreviewModalProps> = ({
   isOpen,
   onClose
 }) => {
-  const [selectedDevice, setSelectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+  const [selectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
   
   const { 
     generatePreviewCampaign, 
@@ -46,8 +46,6 @@ const CampaignPreviewModal: React.FC<CampaignPreviewModalProps> = ({
         <PreviewHeader
           campaignName={campaignName}
           selectedGameType={selectedGameType || 'wheel'}
-          selectedDevice={selectedDevice}
-          onDeviceChange={setSelectedDevice}
           onClose={onClose}
         />
 

--- a/src/components/QuickCampaign/Preview/PreviewHeader.tsx
+++ b/src/components/QuickCampaign/Preview/PreviewHeader.tsx
@@ -1,21 +1,16 @@
 
 import React from 'react';
 import { X } from 'lucide-react';
-import DeviceSelector from './DeviceSelector';
 
 interface PreviewHeaderProps {
   campaignName: string;
   selectedGameType: string;
-  selectedDevice: 'desktop' | 'tablet' | 'mobile';
-  onDeviceChange: (device: 'desktop' | 'tablet' | 'mobile') => void;
   onClose: () => void;
 }
 
 const PreviewHeader: React.FC<PreviewHeaderProps> = ({
   campaignName,
   selectedGameType,
-  selectedDevice,
-  onDeviceChange,
   onClose
 }) => {
   return (
@@ -26,11 +21,6 @@ const PreviewHeader: React.FC<PreviewHeaderProps> = ({
         <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
           {selectedGameType || 'wheel'}
         </span>
-        
-        <DeviceSelector
-          selectedDevice={selectedDevice}
-          onDeviceChange={onDeviceChange}
-        />
       </div>
 
       <button


### PR DESCRIPTION
## Summary
- remove duplicated device selector from preview header to free canvas space on mobile
- adjust quick campaign preview modal accordingly

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: Error: connect ENETUNREACH ...)*

------
https://chatgpt.com/codex/tasks/task_e_689709f42c48832a967e5ea215dfeda5