### PR TITLE
fix: enable mobile file uploads

### DIFF
--- a/src/components/DesignEditor/panels/BackgroundPanel.tsx
+++ b/src/components/DesignEditor/panels/BackgroundPanel.tsx
@@ -81,7 +81,7 @@ const BackgroundPanel: React.FC<BackgroundPanelProps> = ({
         type="file"
         accept="image/*"
         onChange={handleFileUpload}
-        className="hidden"
+        className="sr-only"
       />
 
       {/* Upload Background Image */}

--- a/src/components/DesignEditor/panels/UploadsPanel.tsx
+++ b/src/components/DesignEditor/panels/UploadsPanel.tsx
@@ -106,7 +106,7 @@ const UploadsPanel: React.FC<UploadsPanelProps> = ({ onAddElement }) => {
         type="file"
         onChange={handleFileUpload}
         accept="image/*,video/*,audio/*,.pdf,.doc,.docx"
-        className="hidden"
+        className="sr-only"
         multiple
       />
 

--- a/src/components/LogoUploader.tsx
+++ b/src/components/LogoUploader.tsx
@@ -93,7 +93,7 @@ const LogoUploader: React.FC<LogoUploaderProps> = ({ className }) => {
         <p className="text-gray-600 mb-2">
           <label className="text-[#841b60] cursor-pointer hover:text-[#841b60]/80 transition-colors">
             Cliquez pour télécharger
-            <input type="file" accept="image/*" onChange={e => handleUpload(e.target.files)} className="hidden" />
+            <input type="file" accept="image/*" onChange={e => handleUpload(e.target.files)} className="sr-only" />
           </label>{' '}
           ou glissez-déposez votre logo
         </p>

--- a/src/components/common/ImageUpload.tsx
+++ b/src/components/common/ImageUpload.tsx
@@ -84,7 +84,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
           type="file"
           accept={accept}
           onChange={handleFileChange}
-          className="hidden"
+          className="sr-only"
         />
       </div>
     );
@@ -141,7 +141,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
         type="file"
         accept={accept}
         onChange={handleFileChange}
-        className="hidden"
+        className="sr-only"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- replace hidden file inputs with sr-only to allow mobile upload dialogs

## Testing
- `npm ci` *(fails: connect ENETUNREACH)*
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689707213254832aae7bdd21448ab016