### PR TITLE
Hide zoom slider on mobile devices

### DIFF
--- a/src/components/DesignEditor/components/ZoomSlider.tsx
+++ b/src/components/DesignEditor/components/ZoomSlider.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Minus, Plus, RotateCcw } from 'lucide-react';
+import { isRealMobile } from '@/utils/isRealMobile';
 
 interface ZoomSliderProps {
   zoom: number;
@@ -10,7 +11,7 @@ interface ZoomSliderProps {
   defaultZoom?: number;
 }
 
-const ZoomSlider: React.FC<ZoomSliderProps> = React.memo(({
+const ZoomSlider: React.FC<ZoomSliderProps> = React.memo(({ 
   zoom,
   onZoomChange,
   minZoom = 0.25,
@@ -18,6 +19,9 @@ const ZoomSlider: React.FC<ZoomSliderProps> = React.memo(({
   step = 0.05,
   defaultZoom = 1
 }) => {
+  if (isRealMobile()) {
+    return null;
+  }
   const zoomPercent = Math.round(zoom * 100);
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- Hide ZoomSlider on real mobile devices while preserving pinch zoom functionality

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_689712dea18c832a8a2f3c307127bcf8