### PR TITLE
feat: enforce two-color wheel segments

### DIFF
--- a/src/components/DesignEditor/DesignEditorLayout.tsx
+++ b/src/components/DesignEditor/DesignEditorLayout.tsx
@@ -15,12 +15,12 @@ import KeyboardShortcutsHelp from '../shared/KeyboardShortcutsHelp';
 import MobileStableEditor from './components/MobileStableEditor';
 
 const DesignEditorLayout: React.FC = () => {
-  // Détection automatique de l'appareil
+  // Détection automatique de l'appareil basée sur l'user-agent pour éviter le basculement lors du redimensionnement de fenêtre
   const detectDevice = (): 'desktop' | 'tablet' | 'mobile' => {
-    const width = window.innerWidth;
-    if (width >= 1024) return 'desktop';
-    if (width >= 768) return 'tablet';
-    return 'mobile';
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    if (/Mobi|Android/i.test(ua)) return 'mobile';
+    if (/Tablet|iPad/i.test(ua)) return 'tablet';
+    return 'desktop';
   };
 
   // Zoom par défaut selon l'appareil
@@ -363,6 +363,11 @@ const DesignEditorLayout: React.FC = () => {
       showFunnel
     });
 
+    const primaryColor = canvasBackground.type === 'image' && extractedColors[0]
+      ? extractedColors[0]
+      : currentWheelConfig.borderColor;
+    const secondaryColor = '#ffffff';
+
     return {
       id: 'wheel-design-preview',
       type: 'wheel',
@@ -372,8 +377,8 @@ const DesignEditorLayout: React.FC = () => {
         customImages: customImages,
         extractedColors: extractedColors,
         customColors: {
-          primary: extractedColors[0] || campaignConfig.buttonColor || '#841b60',
-          secondary: extractedColors[1] || '#4ecdc4',
+          primary: primaryColor,
+          secondary: secondaryColor,
           accent: extractedColors[2] || '#45b7d1'
         },
         wheelConfig: currentWheelConfig,
@@ -382,10 +387,10 @@ const DesignEditorLayout: React.FC = () => {
       gameConfig: {
         wheel: {
           segments: [
-            { id: '1', label: 'Prix 1', color: extractedColors[0] || '#841b60', probability: 0.25, isWinning: true },
-            { id: '2', label: 'Prix 2', color: extractedColors[1] || '#4ecdc4', probability: 0.25, isWinning: true },
-            { id: '3', label: 'Prix 3', color: extractedColors[0] || '#841b60', probability: 0.25, isWinning: true },
-            { id: '4', label: 'Dommage', color: extractedColors[1] || '#4ecdc4', probability: 0.25, isWinning: false }
+            { id: '1', label: 'Prix 1', color: primaryColor, textColor: secondaryColor, probability: 0.25, isWinning: true },
+            { id: '2', label: 'Prix 2', color: secondaryColor, textColor: primaryColor, probability: 0.25, isWinning: true },
+            { id: '3', label: 'Prix 3', color: primaryColor, textColor: secondaryColor, probability: 0.25, isWinning: true },
+            { id: '4', label: 'Dommage', color: secondaryColor, textColor: primaryColor, probability: 0.25, isWinning: false }
           ],
           winProbability: 0.75,
           maxWinners: 100,
@@ -394,7 +399,7 @@ const DesignEditorLayout: React.FC = () => {
       },
       buttonConfig: {
         text: buttonElement?.content || 'Faire tourner',
-        color: extractedColors[0] || campaignConfig.buttonColor || '#841b60',
+        color: primaryColor,
         textColor: buttonElement?.style?.color || '#ffffff',
         borderRadius: campaignConfig.borderRadius || '8px'
       },

--- a/src/components/DesignEditor/HybridSidebar.tsx
+++ b/src/components/DesignEditor/HybridSidebar.tsx
@@ -70,20 +70,13 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
   // Détecter si on est sur mobile avec un hook React pour éviter les erreurs hydration
   const [isCollapsed, setIsCollapsed] = useState(false);
   
-  // Détecter la taille d'écran de manière sécurisée
+  // Détecter si l'appareil est réellement mobile via l'user-agent plutôt que la taille de la fenêtre
   React.useEffect(() => {
-    const checkIsMobile = () => {
-      const mobile = window.innerWidth < 768;
-      if (mobile && !isCollapsed) {
-        setIsCollapsed(true);
-      }
-    };
-    
-    checkIsMobile();
-    window.addEventListener('resize', checkIsMobile);
-    
-    return () => window.removeEventListener('resize', checkIsMobile);
-  }, [isCollapsed]);
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    if (/Mobi|Android/i.test(ua)) {
+      setIsCollapsed(true);
+    }
+  }, []);
   const [activeTab, setActiveTab] = useState<string | null>('assets');
   
   // Gérer l'affichage des panneaux spéciaux

--- a/src/components/GameTypes/WheelPreview.tsx
+++ b/src/components/GameTypes/WheelPreview.tsx
@@ -36,12 +36,13 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   const gameDimensions = getResponsiveDimensions(previewDevice);
 
   // Récupérer les segments depuis la configuration de la campagne (brut)
+  const primaryFallback = campaign.design?.customColors?.primary || '#ff6b6b';
   const segments = campaign.gameConfig?.wheel?.segments ||
                    campaign.config?.roulette?.segments || [
-    { id: '1', label: 'Prix 1', color: campaign.design?.customColors?.primary || '#ff6b6b' },
-    { id: '2', label: 'Prix 2', color: campaign.design?.customColors?.secondary || '#4ecdc4' },
-    { id: '3', label: 'Prix 3', color: campaign.design?.customColors?.primary || '#45b7d1' },
-    { id: '4', label: 'Dommage',  color: campaign.design?.customColors?.secondary || '#feca57' }
+    { id: '1', label: 'Prix 1', color: primaryFallback },
+    { id: '2', label: 'Prix 2', color: '#ffffff' },
+    { id: '3', label: 'Prix 3', color: primaryFallback },
+    { id: '4', label: 'Dommage',  color: '#ffffff' }
   ];
 
 
@@ -56,17 +57,15 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
       || campaign.design?.customColors?.primary
       || extractedColors[0]
       || '#841b60';
-    const secondaryRef = campaign.design?.customColors?.secondary || extractedColors[1] || '#ffffff';
+    const secondaryRef = '#ffffff';
 
     return segments.map((segment: any, index: number) => {
-      // Alterner primaire / blanc (ou secondaire) pour un rendu net et lisible
-      const color = index % 2 === 0 ? (segment.color || primaryRef) : secondaryRef;
-      const textColor = index % 2 === 0 ? '#ffffff' : (primaryRef || '#000000');
+      const color = index % 2 === 0 ? primaryRef : secondaryRef;
       return {
         id: segment.id || index.toString(),
         label: segment.label,
         color,
-        textColor
+        textColor: index % 2 === 0 ? secondaryRef : primaryRef
       };
     });
   }, [segments, wheelModalConfig?.wheelBorderColor, campaign.design?.customColors, extractedColors]);
@@ -74,7 +73,7 @@ const WheelPreview: React.FC<WheelPreviewProps> = ({
   // Couleurs de marque unifiées - priorité aux customColors de la campagne
   const brandColors = {
     primary: campaign.design?.customColors?.primary || extractedColors[0] || '#841b60',
-    secondary: campaign.design?.customColors?.secondary || extractedColors[1] || '#4ecdc4',
+    secondary: '#ffffff',
     accent: campaign.design?.customColors?.accent || extractedColors[2] || '#45b7d1'
   };
 

--- a/src/services/WheelConfigService.ts
+++ b/src/services/WheelConfigService.ts
@@ -89,32 +89,35 @@ export class WheelConfigService {
  
     };
 
-    // Priorité 3: Couleurs extraites (uniquement si style classic et pas de couleur manuelle)
-    const extractedConfig: Partial<{ borderColor: string; borderWidth: number }> = extractedColors.length > 0 && designConfig.borderStyle === 'classic' ? {
-      borderColor: modalConfig.borderColor || designConfig.borderColor || extractedColors[0]
-    } : {};
+    // Déterminer si une image de fond est utilisée
+    const hasImageBackground = campaign?.design?.background?.type === 'image';
+
+    // Couleur primaire : extraite de l'image si disponible, sinon couleur de la bordure
+    const primaryColor = hasImageBackground && extractedColors[0]
+      ? extractedColors[0]
+      : (modalConfig.borderColor || designConfig.borderColor || defaults.borderColor);
 
     // Fusion avec priorités
     const finalConfig: WheelConfig = {
       borderStyle: modalConfig.borderStyle || designConfig.borderStyle || defaults.borderStyle,
-      borderColor: modalConfig.borderColor || designConfig.borderColor || extractedConfig.borderColor || defaults.borderColor,
+      borderColor: primaryColor,
       borderWidth: modalConfig.borderWidth !== undefined ? modalConfig.borderWidth : (designConfig.borderWidth || defaults.borderWidth),
       scale: modalConfig.scale !== undefined ? modalConfig.scale : (designConfig.scale || defaults.scale),
       showBulbs: modalConfig.showBulbs !== undefined ? modalConfig.showBulbs : (designConfig.showBulbs ?? defaults.showBulbs),
       position: modalConfig.position !== undefined ? modalConfig.position : (designConfig.position ?? defaults.position),
 
       shouldCropWheel: options.shouldCropWheel ?? true,
-      
+
       // Configuration des couleurs avec priorités
       customColors: {
-        primary: modalConfig.borderColor || designConfig.borderColor || extractedColors[0] || defaults.borderColor,
-        secondary: extractedColors[1] || '#4ecdc4',
+        primary: primaryColor,
+        secondary: '#ffffff',
         accent: extractedColors[2] || '#45b7d1'
       },
-      
+
       brandColors: {
-        primary: modalConfig.borderColor || designConfig.borderColor || extractedColors[0] || defaults.borderColor,
-        secondary: campaign?.design?.brandColors?.secondary || '#4ecdc4',
+        primary: primaryColor,
+        secondary: '#ffffff',
         accent: campaign?.design?.brandColors?.accent || '#45b7d1'
       },
 

--- a/src/utils/BrandStyleAnalyzer.ts
+++ b/src/utils/BrandStyleAnalyzer.ts
@@ -423,11 +423,12 @@ export interface BrandColors {
   accent?: string;
 }
 export function applyBrandStyleToWheel(campaign: CampaignData, colors: BrandColors) {
+  const secondaryColor = '#ffffff';
   const updatedSegments = (campaign?.config?.roulette?.segments || []).map(
     (segment, index: number) => ({
       ...segment,
-      color:
-        segment.color || (index % 2 === 0 ? colors.primary : colors.secondary),
+      color: segment.color || (index % 2 === 0 ? colors.primary : secondaryColor),
+      textColor: segment.textColor || (index % 2 === 0 ? secondaryColor : colors.primary),
     }),
   );
   return {
@@ -437,15 +438,15 @@ export function applyBrandStyleToWheel(campaign: CampaignData, colors: BrandColo
       roulette: {
         ...(campaign.config?.roulette || {}),
         borderColor: colors.primary,
-        borderOutlineColor: colors.accent || colors.secondary || colors.primary,
+        borderOutlineColor: colors.accent || colors.primary,
         segmentColor1: colors.primary,
-        segmentColor2: colors.secondary,
+        segmentColor2: secondaryColor,
         segments: updatedSegments,
       },
     },
     design: {
       ...(campaign.design || {}),
-      customColors: colors,
+      customColors: { ...colors, secondary: secondaryColor },
     },
     buttonConfig: {
       ...(campaign.buttonConfig || {}),

--- a/src/utils/brandGameTransformer.ts
+++ b/src/utils/brandGameTransformer.ts
@@ -95,7 +95,7 @@ export const transformBrandGameToCampaign = (concept: GeneratedGameConcept) => {
             borderColor: concept.colors.primary,
             borderOutlineColor: concept.colors.accent,
             segmentColor1: concept.colors.primary,
-            segmentColor2: concept.colors.secondary,
+            segmentColor2: '#ffffff',
             centerLogo: concept.logo,
             premiumPointer: true,
             glowEffect: concept.design.premiumEffects?.glassmorphism || false,
@@ -104,6 +104,8 @@ export const transformBrandGameToCampaign = (concept: GeneratedGameConcept) => {
               id: index,
               winProbability: segment.probability || 0.15,
               premiumStyling: true,
+              color: index % 2 === 0 ? concept.colors.primary : '#ffffff',
+              textColor: index % 2 === 0 ? '#ffffff' : concept.colors.primary,
               gradient: `linear-gradient(45deg, ${segment.color}, ${adjustColorBrightness(segment.color, 20)})`
             })) || []
           }

--- a/src/utils/wheelConfig.ts
+++ b/src/utils/wheelConfig.ts
@@ -21,9 +21,12 @@ export const getWheelSegments = (campaign: any) => {
   if (process.env.NODE_ENV !== 'production') {
     console.log('getWheelSegments - Campaign reçu:', campaign);
   }
-  
-  const segmentColor1 = campaign?.config?.roulette?.segmentColor1 || '#ff6b6b';
-  const segmentColor2 = campaign?.config?.roulette?.segmentColor2 || '#4ecdc4';
+
+  const hasImageBackground = campaign?.design?.background?.type === 'image';
+  const extractedPrimary = campaign?.design?.extractedColors?.[0];
+  const defaultPrimary = campaign?.config?.roulette?.segmentColor1 || campaign?.design?.wheelConfig?.borderColor || '#ff6b6b';
+  const segmentColor1 = hasImageBackground && extractedPrimary ? extractedPrimary : defaultPrimary;
+  const segmentColor2 = '#ffffff';
 
   // Vérifier plusieurs sources pour les segments
   let originalSegments = 
@@ -47,7 +50,7 @@ export const getWheelSegments = (campaign: any) => {
   const segments = originalSegments.map((segment: any, index: number) => ({
     ...segment,
     color: segment.color || (index % 2 === 0 ? segmentColor1 : segmentColor2),
-    textColor: segment.textColor || '#ffffff',
+    textColor: segment.textColor || (index % 2 === 0 ? segmentColor2 : segmentColor1),
     id: segment.id || `segment-${index}`
   }));
 

--- a/test/wheelConfig.test.ts
+++ b/test/wheelConfig.test.ts
@@ -10,11 +10,16 @@ test('getWheelSegments fills missing colors', () => {
         segmentColor1: '#111111',
         segmentColor2: '#222222'
       }
+    },
+    design: {
+      background: { type: 'color', value: '#000000' }
     }
   };
   const segments = getWheelSegments(campaign);
   assert.equal(segments[0].color, '#111111');
-  assert.equal(segments[1].color, '#222222');
+  assert.equal(segments[1].color, '#ffffff');
+  assert.equal(segments[0].textColor, '#ffffff');
+  assert.equal(segments[1].textColor, '#111111');
 });
 
 test('getWheelDimensions returns expected pointer size', () => {


### PR DESCRIPTION
## Summary
- enforce two-color wheel segments alternating primary and white
- extract primary color from background image or border color if no image
- update wheel utilities and preview logic for inverted text colors
- prevent desktop users from losing the sidebar when resizing by detecting device via user agent

## Testing
- `npm ci` *(failed: connect ENETUNREACH 140.82.112.4:443)*
- `npm test` *(failed: Dependency "tsx" is missing. Run `npm ci` before running tests.)*


------
https://chatgpt.com/codex/tasks/task_e_689751af3494832ab961f818d11d135a