### PR TITLE
Redirect campaign editor links to design editor

### DIFF
--- a/src/components/QuickCampaign/Step4Finalization.tsx
+++ b/src/components/QuickCampaign/Step4Finalization.tsx
@@ -98,8 +98,8 @@ const Step4Finalization: React.FC = () => {
       
       console.log('Editor config created:', editorConfig);
       
-      // Navigate to campaign editor
-      navigate('/campaign-editor');
+      // Navigate to design editor
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/QuickCampaign/Studio/StudioPreview.tsx
+++ b/src/components/QuickCampaign/Studio/StudioPreview.tsx
@@ -149,7 +149,7 @@ const StudioPreview: React.FC<StudioPreviewProps> = ({
       console.log('Transferring Studio data:', { fullCampaignData, editorConfig });
       
       // Naviguer vers l'éditeur avec rechargement forcé
-      window.location.href = '/campaign-editor';
+      window.location.href = '/design-editor';
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/funnels/components/ResultScreen.tsx
+++ b/src/components/funnels/components/ResultScreen.tsx
@@ -88,7 +88,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({
       localStorage.setItem('campaignPreview', JSON.stringify(campaign));
       localStorage.setItem('editorConfig', JSON.stringify(editorConfig));
       
-      navigate('/campaign-editor');
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -188,7 +188,7 @@ const Campaigns: React.FC = () => {
               Création rapide
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -71,14 +71,14 @@ const Gamification: React.FC = () => {
         actions={
           <div className="flex gap-x-4">
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
               Éditeur de Jeux
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
@@ -112,7 +112,7 @@ const Gamification: React.FC = () => {
                     <h3 className="font-bold text-gray-800 mb-1">{game.name}</h3>
                     <p className="text-sm text-gray-600 mb-4">{game.description}</p>
                     <Link
-                      to="/campaign-editor"
+                      to="/design-editor"
                       className="w-full px-4 py-2 bg-gray-100 text-gray-800 font-medium rounded-lg hover:bg-[#841b60] hover:text-white transition-colors duration-200 block text-center"
                     >
                       Créer avec l'éditeur


### PR DESCRIPTION
## Summary
- Redirect campaign links and navigation to `/design-editor`

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.113.4:443 during onnxruntime-node install)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6b74d70832a9db30cd79bfa2738