### PR TITLE
Redirect campaign editor links to design editor and improve mobile canvas responsiveness

### DIFF
--- a/src/components/DesignEditor/components/MobileResponsiveLayout.tsx
+++ b/src/components/DesignEditor/components/MobileResponsiveLayout.tsx
@@ -175,7 +175,11 @@ const MobileResponsiveLayout: React.FC<MobileResponsiveLayoutProps> = ({
           flex-direction: column;
           height: 100vh;
           max-height: 100vh;
-          
+          min-height: 100vh;
+          height: 100dvh;
+          max-height: 100dvh;
+          min-height: 100dvh;
+
           /* Empêcher le scroll */
           overscroll-behavior: none;
           touch-action: manipulation;

--- a/src/components/DesignEditor/hooks/useMobileCanvasLock.ts
+++ b/src/components/DesignEditor/hooks/useMobileCanvasLock.ts
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useRef } from 'react';
+import { isRealMobile } from '../../../utils/isRealMobile';
 
 interface UseMobileCanvasLockOptions {
   canvasRef: React.RefObject<HTMLDivElement>;
@@ -15,12 +16,14 @@ export const useMobileCanvasLock = ({
   isTablet,
   zoom
 }: UseMobileCanvasLockOptions) => {
+  const isRealDevice = isRealMobile();
+  const isMobileDevice = isMobile || isTablet || isRealDevice;
   const isDraggingRef = useRef(false);
   const lastTouchRef = useRef<{ x: number; y: number } | null>(null);
 
   // Fonction pour bloquer les interactions non désirées sur le canvas
   const preventCanvasInterference = useCallback((event: TouchEvent | MouseEvent) => {
-    if (!canvasRef.current || (!isMobile && !isTablet)) return;
+    if (!canvasRef.current || !isMobileDevice) return;
 
     const target = event.target as HTMLElement;
     
@@ -68,11 +71,11 @@ export const useMobileCanvasLock = ({
         lastTouchRef.current = null;
       }
     }
-  }, [canvasRef, isMobile, isTablet]);
+  }, [canvasRef, isMobileDevice]);
 
   // Fonction pour empêcher le scroll du canvas pendant le drag d'éléments
   const preventScrollDuringDrag = useCallback((event: TouchEvent) => {
-    if (!canvasRef.current || (!isMobile && !isTablet)) return;
+    if (!canvasRef.current || !isMobileDevice) return;
 
     const target = event.target as HTMLElement;
     const isDraggableElement = target.closest('[data-element-id]');
@@ -83,33 +86,33 @@ export const useMobileCanvasLock = ({
         event.preventDefault();
       }
     }
-  }, [canvasRef, isMobile, isTablet]);
+  }, [canvasRef, isMobileDevice]);
 
   // Fonction pour gérer le début du drag
   const handleDragStart = useCallback(() => {
     isDraggingRef.current = true;
-    
+
     // Bloquer le scroll du body pendant le drag
-    if (isMobile || isTablet) {
+    if (isMobileDevice) {
       document.body.style.overflow = 'hidden';
       document.body.style.touchAction = 'none';
     }
-  }, [isMobile, isTablet]);
+  }, [isMobileDevice]);
 
   // Fonction pour gérer la fin du drag
   const handleDragEnd = useCallback(() => {
     isDraggingRef.current = false;
-    
+
     // Restaurer le scroll du body
-    if (isMobile || isTablet) {
+    if (isMobileDevice) {
       document.body.style.overflow = '';
       document.body.style.touchAction = '';
     }
-  }, [isMobile, isTablet]);
+  }, [isMobileDevice]);
 
   // Fonction pour assurer la visibilité complète du canvas
   const ensureCanvasVisibility = useCallback(() => {
-    if (!canvasRef.current || (!isMobile && !isTablet)) return;
+    if (!canvasRef.current || !isMobileDevice) return;
 
     const canvas = canvasRef.current;
     const canvasRect = canvas.getBoundingClientRect();
@@ -135,11 +138,11 @@ export const useMobileCanvasLock = ({
       });
       window.dispatchEvent(adjustZoomEvent);
     }
-  }, [canvasRef, isMobile, isTablet]);
+  }, [canvasRef, isMobileDevice]);
 
   // Installation des écouteurs d'événements
   useEffect(() => {
-    if (!canvasRef.current || (!isMobile && !isTablet)) return;
+    if (!canvasRef.current || !isMobileDevice) return;
 
     const canvas = canvasRef.current;
 
@@ -194,7 +197,7 @@ export const useMobileCanvasLock = ({
       document.body.style.overflow = '';
       document.body.style.touchAction = '';
     };
-  }, [canvasRef, isMobile, isTablet, preventCanvasInterference, preventScrollDuringDrag, handleDragStart, handleDragEnd]);
+  }, [canvasRef, isMobileDevice, preventCanvasInterference, preventScrollDuringDrag, handleDragStart, handleDragEnd]);
 
   // Vérifier la visibilité du canvas lors des changements
   useEffect(() => {
@@ -203,7 +206,7 @@ export const useMobileCanvasLock = ({
 
   // Vérifier la visibilité lors du redimensionnement
   useEffect(() => {
-    if (!isMobile && !isTablet) return;
+    if (!isMobileDevice) return;
 
     const handleResize = () => {
       setTimeout(ensureCanvasVisibility, 100); // Délai pour laisser le temps au redimensionnement
@@ -220,7 +223,7 @@ export const useMobileCanvasLock = ({
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('orientationchange', handleOrientationChange);
     };
-  }, [isMobile, isTablet, ensureCanvasVisibility]);
+  }, [isMobileDevice, ensureCanvasVisibility]);
 
   return {
     isDragging: isDraggingRef.current,

--- a/src/components/QuickCampaign/Step4Finalization.tsx
+++ b/src/components/QuickCampaign/Step4Finalization.tsx
@@ -98,8 +98,8 @@ const Step4Finalization: React.FC = () => {
       
       console.log('Editor config created:', editorConfig);
       
-      // Navigate to campaign editor
-      navigate('/campaign-editor');
+      // Navigate to design editor
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/QuickCampaign/Studio/StudioPreview.tsx
+++ b/src/components/QuickCampaign/Studio/StudioPreview.tsx
@@ -149,7 +149,7 @@ const StudioPreview: React.FC<StudioPreviewProps> = ({
       console.log('Transferring Studio data:', { fullCampaignData, editorConfig });
       
       // Naviguer vers l'éditeur avec rechargement forcé
-      window.location.href = '/campaign-editor';
+      window.location.href = '/design-editor';
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/components/funnels/components/ResultScreen.tsx
+++ b/src/components/funnels/components/ResultScreen.tsx
@@ -88,7 +88,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({
       localStorage.setItem('campaignPreview', JSON.stringify(campaign));
       localStorage.setItem('editorConfig', JSON.stringify(editorConfig));
       
-      navigate('/campaign-editor');
+      navigate('/design-editor');
     } catch (error) {
       console.error('Erreur lors du transfert vers l\'éditeur:', error);
     }

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -188,7 +188,7 @@ const Campaigns: React.FC = () => {
               Création rapide
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -71,14 +71,14 @@ const Gamification: React.FC = () => {
         actions={
           <div className="flex gap-x-4">
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gradient-to-br from-[#841b60] to-[#b41b60] text-white font-semibold rounded-xl hover:bg-[#6d164f] transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
               Éditeur de Jeux
             </Link>
             <Link
-              to="/campaign-editor"
+              to="/design-editor"
               className="inline-flex items-center px-6 py-2.5 bg-gray-600 text-white font-semibold rounded-xl hover:bg-gray-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 text-base"
             >
               <Plus className="w-5 h-5 mr-2" />
@@ -112,7 +112,7 @@ const Gamification: React.FC = () => {
                     <h3 className="font-bold text-gray-800 mb-1">{game.name}</h3>
                     <p className="text-sm text-gray-600 mb-4">{game.description}</p>
                     <Link
-                      to="/campaign-editor"
+                      to="/design-editor"
                       className="w-full px-4 py-2 bg-gray-100 text-gray-800 font-medium rounded-lg hover:bg-[#841b60] hover:text-white transition-colors duration-200 block text-center"
                     >
                       Créer avec l'éditeur


### PR DESCRIPTION
## Summary
- Redirect campaign links and navigation to `/design-editor`
- Ensure design editor canvas uses dynamic viewport height for visibility on real mobile devices
- Guard mobile canvas interactions with real device detection

## Testing
- `npm ci` *(fails: connect ENETUNREACH 140.82.112.4:443 during onnxruntime-node install)*
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6b74d70832a9db30cd79bfa2738