### PR TITLE
fix: show mobile tab bar in design editor

### DIFF
--- a/src/components/DesignEditor/DesignEditorLayout.tsx
+++ b/src/components/DesignEditor/DesignEditorLayout.tsx
@@ -24,7 +24,7 @@ const DesignEditorLayout: React.FC = () => {
   };
 
   // Détection de l'appareil physique réel (pour l'interface)
-  const actualDevice = detectDevice();
+  const [actualDevice, setActualDevice] = useState<'desktop' | 'tablet' | 'mobile'>(detectDevice());
 
   // Zoom par défaut selon l'appareil
   const getDefaultZoom = (device: 'desktop' | 'tablet' | 'mobile'): number => {
@@ -49,7 +49,7 @@ const DesignEditorLayout: React.FC = () => {
   } = useEditorStore();
 
   // État local pour la compatibilité existante
-  const [selectedDevice, setSelectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>(detectDevice());
+  const [selectedDevice, setSelectedDevice] = useState<'desktop' | 'tablet' | 'mobile'>(actualDevice);
 
   // Gestionnaire de changement d'appareil avec ajustement automatique du zoom
   const handleDeviceChange = (device: 'desktop' | 'tablet' | 'mobile') => {
@@ -64,6 +64,14 @@ const DesignEditorLayout: React.FC = () => {
     value: 'linear-gradient(135deg, #87CEEB 0%, #98FB98 100%)'
   });
   const [canvasZoom, setCanvasZoom] = useState(getDefaultZoom(selectedDevice));
+
+  // Synchronise l'état de l'appareil réel et sélectionné après le montage (corrige les différences entre Lovable et Safari)
+  useEffect(() => {
+    const device = detectDevice();
+    setActualDevice(device);
+    setSelectedDevice(device);
+    setCanvasZoom(getDefaultZoom(device));
+  }, []);
   
   // Référence pour le canvas
   const canvasRef = useRef<HTMLDivElement>(null);
@@ -675,7 +683,7 @@ const DesignEditorLayout: React.FC = () => {
       )}
       
       {/* Main Content */}
-      <div className="flex-1 flex overflow-hidden relative">
+      <div className={`flex-1 flex overflow-hidden relative ${actualDevice === 'mobile' ? 'pb-20' : ''}`}>
         {showFunnel ? (
           /* Funnel Preview Mode */
           <div className="group fixed inset-0 z-40 w-full h-[100dvh] min-h-[100dvh] overflow-hidden bg-transparent flex">
@@ -695,31 +703,29 @@ const DesignEditorLayout: React.FC = () => {
         ) : (
           /* Design Editor Mode */
           <>
-            {/* Hybrid Sidebar - Design & Technical (always visible on PC/desktop, hidden only on actual mobile devices) */}
-            {actualDevice !== 'mobile' && (
-              <HybridSidebar 
-                onAddElement={handleAddElement}
-                onBackgroundChange={handleBackgroundChange}
-                onExtractedColorsChange={handleExtractedColorsChange}
-                campaignConfig={campaignConfig}
-                onCampaignConfigChange={handleCampaignConfigChange}
-                elements={canvasElements}
-                onElementsChange={setCanvasElements}
-                selectedElement={selectedElement}
-                onElementUpdate={handleElementUpdate}
-                showEffectsPanel={showEffectsInSidebar}
-                onEffectsPanelChange={setShowEffectsInSidebar}
-                showAnimationsPanel={showAnimationsInSidebar}
-                onAnimationsPanelChange={setShowAnimationsInSidebar}
-                showPositionPanel={showPositionInSidebar}
-                onPositionPanelChange={setShowPositionInSidebar}
-                canvasRef={canvasRef}
-                selectedElements={selectedElements}
-                onSelectedElementsChange={setSelectedElements}
-                onAddToHistory={addToHistory}
-              />
-            )}
-            
+            {/* Hybrid Sidebar - Design & Technical */}
+            <HybridSidebar
+              onAddElement={handleAddElement}
+              onBackgroundChange={handleBackgroundChange}
+              onExtractedColorsChange={handleExtractedColorsChange}
+              campaignConfig={campaignConfig}
+              onCampaignConfigChange={handleCampaignConfigChange}
+              elements={canvasElements}
+              onElementsChange={setCanvasElements}
+              selectedElement={selectedElement}
+              onElementUpdate={handleElementUpdate}
+              showEffectsPanel={showEffectsInSidebar}
+              onEffectsPanelChange={setShowEffectsInSidebar}
+              showAnimationsPanel={showAnimationsInSidebar}
+              onAnimationsPanelChange={setShowAnimationsInSidebar}
+              showPositionPanel={showPositionInSidebar}
+              onPositionPanelChange={setShowPositionInSidebar}
+              canvasRef={canvasRef}
+              selectedElements={selectedElements}
+              onSelectedElementsChange={setSelectedElements}
+              onAddToHistory={addToHistory}
+            />
+
             {/* Main Canvas Area */}
             <DesignCanvas 
               selectedDevice={selectedDevice}

--- a/src/components/DesignEditor/HybridSidebar.tsx
+++ b/src/components/DesignEditor/HybridSidebar.tsx
@@ -69,12 +69,14 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
 }) => {
   // Détecter si on est sur mobile avec un hook React pour éviter les erreurs hydration
   const [isCollapsed, setIsCollapsed] = useState(false);
-  
+  const [isMobileDevice, setIsMobileDevice] = useState(false);
+
   // Détecter si l'appareil est réellement mobile via l'user-agent plutôt que la taille de la fenêtre
   React.useEffect(() => {
     const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
     if (/Mobi|Android/i.test(ua)) {
       setIsCollapsed(true);
+      setIsMobileDevice(true);
     }
   }, []);
   const [activeTab, setActiveTab] = useState<string | null>('assets');
@@ -241,6 +243,40 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
   };
 
   if (isCollapsed) {
+    if (isMobileDevice) {
+      return (
+        <div className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 flex">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <button
+                key={tab.id}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsCollapsed(false);
+                  setActiveTab(tab.id);
+                }}
+                onTouchStart={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                className={`flex-1 p-3 flex flex-col items-center justify-center transition-colors ${
+                  activeTab === tab.id
+                    ? 'bg-[hsl(var(--sidebar-active-bg))] text-[hsl(var(--sidebar-icon-active))]'
+                    : 'text-gray-600'
+                }`}
+                title={tab.label}
+              >
+                <Icon className="w-5 h-5 mb-1" />
+                <span className="text-xs">{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      );
+    }
+
     return (
       <div className="w-16 bg-white border-r border-gray-200 flex flex-col">
         {/* Collapse/Expand Button */}
@@ -251,7 +287,7 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
         >
           <ChevronRight className="w-5 h-5 text-gray-600" />
         </button>
-        
+
         {/* Collapsed Icons */}
         <div className="flex flex-col space-y-2 p-2">
           {tabs.map((tab) => {
@@ -277,7 +313,7 @@ const HybridSidebar: React.FC<HybridSidebarProps> = React.memo(({
                     : 'text-gray-600 hover:bg-gray-100'
                 }`}
                 title={tab.label}
-                style={{ 
+                style={{
                   pointerEvents: 'auto',
                   userSelect: 'none'
                 }}

--- a/src/components/DesignEditor/hooks/useMobileOptimization.ts
+++ b/src/components/DesignEditor/hooks/useMobileOptimization.ts
@@ -127,11 +127,11 @@ export const useMobileOptimization = (
     
     const preventBounce = (e: TouchEvent) => {
       const target = e.target as HTMLElement;
-      
+
       // Permettre le scroll uniquement dans les zones scrollables spécifiques
       const isScrollableArea = target.closest('.scrollable-area, .sidebar-content, .panel-content');
-      
-      if (!isScrollableArea) {
+
+      if (!isScrollableArea && e.type === 'touchmove' && e.cancelable) {
         e.preventDefault();
       }
     };


### PR DESCRIPTION
## Summary
- remove device guard to render sidebar on mobile
- add bottom tab bar for mobile devices

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_689a273a5820832a9579443406122281