### PR TITLE
style: add top bar and pastel dashboard background

### DIFF
--- a/src/components/Dashboard/StatsGrid.tsx
+++ b/src/components/Dashboard/StatsGrid.tsx
@@ -24,7 +24,7 @@ const StatsGrid: React.FC = () => {
     icon: <Calendar className="w-6 h-6 text-[#841b60]" />
   }];
   return <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
-      {stats.map((stat, statIndex) => <div key={statIndex} className="bg-white p-6 rounded-2xl shadow-md hover:shadow-lg transition-shadow duration-300 my-[13px]">
+      {stats.map((stat, statIndex) => <div key={statIndex} className="bg-white p-6 rounded-[28px] shadow-md hover:shadow-lg transition-shadow duration-300 my-[13px]">
           <div className="flex justify-between items-start">
             <div>
               <p className="text-gray-700 font-semibold">{stat.name}</p>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -30,27 +30,34 @@ const Layout: React.FC = () => {
   }, [sidebarCollapsed]);
 
   return (
-    <div className="flex min-h-screen bg-[#ebf4f7] overflow-hidden w-full">
-      <Sidebar />
-      {/* Overlay mobile/tablette pour cliquer et fermer la sidebar */}
-      <div 
-        onClick={toggleSidebar} 
-        className={`md:hidden fixed inset-0 bg-black/30 transition-opacity z-30 ${
-          sidebarCollapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
-        }`} 
-      />
-      <div className="flex-1 flex flex-col min-w-0 max-w-full">
-        <header className="md:hidden flex items-center justify-between bg-white border-b border-gray-200 p-4">
-          <button onClick={toggleSidebar} className="text-gray-500">
-            <Menu className="w-6 h-6" />
-          </button>
-          <img src={logo} alt="Prosplay Logo" className="h-8 w-auto" />
-        </header>
-        <main className="flex-1 overflow-y-auto w-full py-0 px-0">
-          <div className="w-full max-w-full py-0 sm:py-6 px-4 sm:px-6">
-            <Outlet />
-          </div>
-        </main>
+    <div className="relative min-h-screen overflow-hidden w-full">
+      {/* Fond pastel global avec léger débordement */}
+      <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-[calc(100%+4rem)] bg-gradient-to-br from-[#fdf1f5] to-[#fde8ef] -z-10" />
+      {/* Bande violette supérieure */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[calc(100%+4rem)] h-40 bg-[radial-gradient(circle_at_0%_0%,_#841b60,_#b41b60)] rounded-b-[28px] shadow-md -z-0" />
+
+      <div className="relative flex min-h-screen overflow-hidden w-full">
+        <Sidebar />
+        {/* Overlay mobile/tablette pour cliquer et fermer la sidebar */}
+        <div
+          onClick={toggleSidebar}
+          className={`md:hidden fixed inset-0 bg-black/30 transition-opacity z-30 ${
+            sidebarCollapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+          }`}
+        />
+        <div className="flex-1 flex flex-col min-w-0 max-w-full z-10">
+          <header className="md:hidden flex items-center justify-between bg-white border-b border-gray-200 p-4">
+            <button onClick={toggleSidebar} className="text-gray-500">
+              <Menu className="w-6 h-6" />
+            </button>
+            <img src={logo} alt="Prosplay Logo" className="h-8 w-auto" />
+          </header>
+          <main className="flex-1 overflow-y-auto w-full py-0 px-0">
+            <div className="w-full max-w-full py-0 sm:py-6 px-4 sm:px-6">
+              <Outlet />
+            </div>
+          </main>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add full-width violet gradient banner with rounded bottom to layout
- introduce soft pastel background that bleeds outside content for layered effect
- round dashboard stat cards to 28px

## Testing
- `npm test` *(fails: Dependency "tsx" is missing)*
- `npm ci` *(fails: connect ENETUNREACH to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_689a80705df8832abe7708a1297b285d