### PR TITLE
fix: init campaign in mobile drawer

### DIFF
--- a/src/components/ModelEditor/components/MobileSidebarDrawer.tsx
+++ b/src/components/ModelEditor/components/MobileSidebarDrawer.tsx
@@ -44,6 +44,7 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
   onBackgroundChange,
   onExtractedColorsChange,
   currentBackground,
+  campaignConfig,
   elements = [],
   onElementsChange,
   selectedElement,
@@ -55,6 +56,11 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
 }) => {
   const campaign = useEditorStore((s: any) => s.campaign);
   const setCampaign = useEditorStore((s: any) => s.setCampaign);
+  useEffect(() => {
+    if (!campaign && campaignConfig) {
+      setCampaign(campaignConfig);
+    }
+  }, [campaign, campaignConfig, setCampaign]);
   const [activeTab, setActiveTab] = useState<string>('elements');
   const [isMinimized, setIsMinimized] = useState(true);
 

--- a/src/components/QuizEditor/components/MobileSidebarDrawer.tsx
+++ b/src/components/QuizEditor/components/MobileSidebarDrawer.tsx
@@ -45,6 +45,7 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
   onBackgroundChange,
   onExtractedColorsChange,
   currentBackground,
+  campaignConfig,
   elements = [],
   onElementsChange,
   selectedElement,
@@ -56,6 +57,11 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
 }) => {
   const campaign = useEditorStore((s: any) => s.campaign);
   const setCampaign = useEditorStore((s: any) => s.setCampaign);
+  useEffect(() => {
+    if (!campaign && campaignConfig) {
+      setCampaign(campaignConfig);
+    }
+  }, [campaign, campaignConfig, setCampaign]);
   const [activeTab, setActiveTab] = useState<string>('elements');
   const [isMinimized, setIsMinimized] = useState(true);
 


### PR DESCRIPTION
## Summary
- initialize campaign in mobile sidebars when store empty so form fields load

## Testing
- `npm ci` *(fails: ENETUNREACH for onnxruntime download)*
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c02be154548331b84d959c0ad9494b