### PR TITLE
Fix Jackpot preview rendering

### DIFF
--- a/src/components/ModernEditor/components/GameRenderer.tsx
+++ b/src/components/ModernEditor/components/GameRenderer.tsx
@@ -81,6 +81,8 @@ const GameRenderer: React.FC<GameRendererProps> = ({
         return (
           <Jackpot
             {...commonProps}
+            /* Enable interactive jackpot rendering in preview */
+            isPreview
             key={`jackpot-${campaign._lastUpdate || Date.now()}`}
           />
         );


### PR DESCRIPTION
## Summary
- pass `isPreview` to Jackpot component in ModernEditor GameRenderer so the jackpot displays during preview

## Testing
- `npm ci` *(fails: onnxruntime download ENETUNREACH)*
- `npm test` *(fails: Dependency "tsx" is missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c4b6571e3c833194aa60e592571218