### PR TITLE
fix: open jackpot config drawer on mobile

### DIFF
--- a/src/components/ModelEditor/DesignCanvas.tsx
+++ b/src/components/ModelEditor/DesignCanvas.tsx
@@ -1555,6 +1555,8 @@ const DesignCanvas = React.forwardRef<HTMLDivElement, DesignCanvasProps>(({
         canUndo={canUndo}
         canRedo={canRedo}
         onClearSelection={handleClearSelection}
+        showJackpotPanel={showJackpotPanel}
+        onJackpotPanelChange={onJackpotPanelChange}
       >
         {/* Canvas Toolbar - Show for text and shape elements */}
         {(!readOnly) && selectedElementData && (selectedElementData.type === 'text' || selectedElementData.type === 'shape') && (

--- a/src/components/ModelEditor/components/MobileResponsiveLayout.tsx
+++ b/src/components/ModelEditor/components/MobileResponsiveLayout.tsx
@@ -51,6 +51,9 @@ interface MobileResponsiveLayoutProps {
   onJackpotCustomFrameChange?: (frame: any) => void;
   customTemplateUrl?: string;
   onJackpotCustomTemplateChange?: (url: string) => void;
+  // Control jackpot panel drawer
+  showJackpotPanel?: boolean;
+  onJackpotPanelChange?: (show: boolean) => void;
 }
 
 const MobileResponsiveLayout: React.FC<MobileResponsiveLayoutProps> = ({
@@ -95,7 +98,9 @@ const MobileResponsiveLayout: React.FC<MobileResponsiveLayoutProps> = ({
   customFrame,
   onJackpotCustomFrameChange,
   customTemplateUrl,
-  onJackpotCustomTemplateChange
+  onJackpotCustomTemplateChange,
+  showJackpotPanel,
+  onJackpotPanelChange
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isToolbarVisible, setIsToolbarVisible] = useState(false);
@@ -283,6 +288,8 @@ const MobileResponsiveLayout: React.FC<MobileResponsiveLayoutProps> = ({
           onJackpotCustomFrameChange={onJackpotCustomFrameChange}
           customTemplateUrl={customTemplateUrl}
           onJackpotCustomTemplateChange={onJackpotCustomTemplateChange}
+          showJackpotPanel={showJackpotPanel}
+          onJackpotPanelChange={onJackpotPanelChange}
         />
       )}
 

--- a/src/components/ModelEditor/components/MobileSidebarDrawer.tsx
+++ b/src/components/ModelEditor/components/MobileSidebarDrawer.tsx
@@ -52,6 +52,9 @@ interface MobileSidebarDrawerProps {
   onJackpotCustomFrameChange?: (frame: any) => void;
   customTemplateUrl?: string;
   onJackpotCustomTemplateChange?: (url: string) => void;
+  // Control jackpot config drawer externally
+  showJackpotPanel?: boolean;
+  onJackpotPanelChange?: (show: boolean) => void;
 }
 
 const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
@@ -82,7 +85,9 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
   customFrame,
   onJackpotCustomFrameChange,
   customTemplateUrl,
-  onJackpotCustomTemplateChange
+  onJackpotCustomTemplateChange,
+  showJackpotPanel = false,
+  onJackpotPanelChange
 }) => {
   const [activeTab, setActiveTab] = useState<string>('assets');
   const [isMinimized, setIsMinimized] = useState(true);
@@ -115,6 +120,19 @@ const MobileSidebarDrawer: React.FC<MobileSidebarDrawerProps> = ({
       setIsMinimized(false);
     }
   }, [selectedElement, disableAutoOpen]);
+
+  // Ouverture demandée par le parent pour le panneau Jackpot
+  useEffect(() => {
+    if (showJackpotPanel && activeTab !== 'jackpot') {
+      setActiveTab('jackpot');
+      setIsMinimized(false);
+    }
+  }, [showJackpotPanel, activeTab]);
+
+  // Notifier le parent des changements d'onglet Jackpot
+  useEffect(() => {
+    onJackpotPanelChange?.(activeTab === 'jackpot');
+  }, [activeTab, onJackpotPanelChange]);
 
   // Prefetch on hover/touch to smooth first render of heavy tabs
   const prefetchTab = (tabId: string) => {


### PR DESCRIPTION
## Summary
- open Jackpot configuration panel automatically on mobile when editing template or jackpot
- plumb jackpot panel visibility through mobile responsive layout and sidebar drawer

## Testing
- `npm test` *(fails: Dependency "tsx" is missing. Run `npm ci` before running tests.)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.112.3:443)*


------
https://chatgpt.com/codex/tasks/task_b_68c5a92184ec8331bd69cfca691531a8