### PR TITLE
Fix jackpot preview background sync

### DIFF
--- a/src/components/funnels/FunnelUnlockedGame.tsx
+++ b/src/components/funnels/FunnelUnlockedGame.tsx
@@ -44,9 +44,39 @@ const FunnelUnlockedGame: React.FC<FunnelUnlockedGameProps> = ({
   // Mettre à jour la campagne en temps réel quand le store change
   useEffect(() => {
     if ((campaign.type === 'form' || campaign.type === 'jackpot') && storeCampaign) {
-      setLiveCampaign(storeCampaign);
+      const storeBackground =
+        storeCampaign.canvasConfig?.background ?? storeCampaign.design?.background;
+      const campaignBackground =
+        campaign.canvasConfig?.background ?? campaign.design?.background;
+
+      const mergedBackground = storeBackground ?? campaignBackground;
+      const normalizedBackground =
+        mergedBackground && typeof mergedBackground === 'object' && 'value' in mergedBackground
+          ? mergedBackground
+          : mergedBackground
+            ? { type: 'color' as const, value: mergedBackground as string }
+            : undefined;
+
+      setLiveCampaign({
+        ...storeCampaign,
+        canvasConfig: {
+          ...(campaign.canvasConfig || {}),
+          ...(storeCampaign.canvasConfig || {}),
+          background: normalizedBackground
+        },
+        design: {
+          ...(campaign.design || {}),
+          ...(storeCampaign.design || {}),
+          background:
+            normalizedBackground ??
+            storeCampaign.design?.background ??
+            campaign.design?.background
+        }
+      });
+    } else {
+      setLiveCampaign(campaign);
     }
-  }, [storeCampaign, campaign.type]);
+  }, [storeCampaign, campaign]);
   
   const {
     createParticipation


### PR DESCRIPTION
## Summary
- preserve the uploaded background image when syncing jackpot campaigns from the editor store to the live preview
- normalize background data so preview mode can fall back to the editor configuration when the store lacks it

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68cad83ccf608331906197bd5d8c7061