### PR TITLE
Fix quiz editor preview flows

### DIFF
--- a/src/components/GameTypes/Quiz/QuizContainer.tsx
+++ b/src/components/GameTypes/Quiz/QuizContainer.tsx
@@ -9,17 +9,32 @@ interface QuizContainerProps {
   config: any;
   design?: any;
   className?: string;
+  onComplete?: (summary: QuizCompletionSummary) => void;
+  showResultsScreen?: boolean;
+}
+
+export interface QuizCompletionSummary {
+  score: number;
+  total: number;
+  responses: Array<{
+    questionId: string | number;
+    selectedOptionIds: (string | number)[];
+    isCorrect: boolean;
+  }>;
 }
 
 const QuizContainer: React.FC<QuizContainerProps> = ({
   config,
   design = {},
-  className = ''
+  className = '',
+  onComplete,
+  showResultsScreen = true
 }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [selectedAnswers, setSelectedAnswers] = useState<(string | number)[]>([]);
   const [score, setScore] = useState(0);
   const [showResults, setShowResults] = useState(false);
+  const [responses, setResponses] = useState<QuizCompletionSummary['responses']>([]);
 
   // Ensure config exists and has questions
   const questions = config?.questions || [];
@@ -51,20 +66,35 @@ const QuizContainer: React.FC<QuizContainerProps> = ({
   const handleNext = () => {
     // Calculer le score
     const correctAnswers = currentQuestion.options?.filter((opt: any) => opt.isCorrect) || [];
-    const isCorrect = selectedAnswers.some(answer => 
+    const isCorrect = selectedAnswers.some(answer =>
       correctAnswers.some((correct: any) => correct.id === answer)
     );
-    
-    if (isCorrect) {
-      setScore(prev => prev + 1);
-    }
+
+    const nextScore = isCorrect ? score + 1 : score;
+    const responseEntry = {
+      questionId: currentQuestion.id ?? currentQuestionIndex,
+      selectedOptionIds: [...selectedAnswers],
+      isCorrect
+    };
+
+    const updatedResponses = [...responses, responseEntry];
+
+    setScore(nextScore);
+    setResponses(updatedResponses);
 
     // Passer à la question suivante ou afficher les résultats
     if (currentQuestionIndex < questions.length - 1) {
       setCurrentQuestionIndex(prev => prev + 1);
       setSelectedAnswers([]);
     } else {
-      setShowResults(true);
+      if (showResultsScreen) {
+        setShowResults(true);
+      }
+      onComplete?.({
+        score: nextScore,
+        total: questions.length,
+        responses: updatedResponses
+      });
     }
   };
 
@@ -73,6 +103,7 @@ const QuizContainer: React.FC<QuizContainerProps> = ({
     setSelectedAnswers([]);
     setScore(0);
     setShowResults(false);
+    setResponses([]);
   };
 
   const getContainerStyle = () => ({

--- a/src/components/GameTypes/QuizGame.tsx
+++ b/src/components/GameTypes/QuizGame.tsx
@@ -1,17 +1,20 @@
 
 import React from 'react';
-import QuizContainer from './Quiz/QuizContainer';
+import QuizContainer, { QuizCompletionSummary } from './Quiz/QuizContainer';
 import { createEnhancedQuizDesign } from '../../utils/quizConfigSync';
 
 interface QuizGameProps {
   config: any;
   design?: any;
-  onGameComplete?: (result: any) => void;
+  onGameComplete?: (result: QuizCompletionSummary) => void;
+  showResultsScreen?: boolean;
 }
 
 const QuizGame: React.FC<QuizGameProps> = ({
   config,
-  design = {}
+  design = {},
+  onGameComplete,
+  showResultsScreen = true
 }) => {
   const questions = config?.questions || [];
 
@@ -31,10 +34,12 @@ const QuizGame: React.FC<QuizGameProps> = ({
 
   // Use QuizContainer directly instead of wrapping it
   return (
-    <QuizContainer 
+    <QuizContainer
       config={config}
       design={enhancedDesign}
       className="max-w-2xl mx-auto"
+      onComplete={onGameComplete}
+      showResultsScreen={showResultsScreen}
     />
   );
 };

--- a/src/components/QuizEditor/DesignEditorLayout.tsx
+++ b/src/components/QuizEditor/DesignEditorLayout.tsx
@@ -1695,7 +1695,7 @@ const QuizEditorLayout: React.FC<QuizEditorLayoutProps> = ({ mode = 'campaign', 
               elements={canvasElements}
               onElementsChange={setCanvasElements}
               background={canvasBackground}
-              campaign={campaignConfig}
+              campaign={campaignData}
               onCampaignChange={handleCampaignConfigChange}
               zoom={canvasZoom}
               onZoomChange={setCanvasZoom}

--- a/src/components/funnels/FunnelQuizParticipate.tsx
+++ b/src/components/funnels/FunnelQuizParticipate.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import FormHandler from './components/FormHandler';
 import { useParticipations } from '../../hooks/useParticipations';
 import { FieldConfig } from '../forms/DynamicContactForm';
+import QuizGame from '../GameTypes/QuizGame';
+import type { QuizCompletionSummary } from '../GameTypes/Quiz/QuizContainer';
 
 interface FunnelQuizParticipateProps {
   campaign: any;
@@ -13,11 +15,14 @@ interface FunnelQuizParticipateProps {
 const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign, previewMode }) => {
   const [phase, setPhase] = useState<'participate' | 'quiz' | 'form' | 'thankyou'>('participate');
   const [score, setScore] = useState<number>(0);
-  
+  const [totalQuestions, setTotalQuestions] = useState<number>(0);
+  const [quizResponses, setQuizResponses] = useState<QuizCompletionSummary['responses']>([]);
+
   const [showFormModal, setShowFormModal] = useState<boolean>(false);
   const [participationLoading, setParticipationLoading] = useState<boolean>(false);
 
   const showScore = !!campaign?.gameConfig?.quiz?.showScore;
+  const quizConfig = campaign?.gameConfig?.quiz;
 
   const { createParticipation } = useParticipations();
 
@@ -36,10 +41,28 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
   }), [campaign?.design?.background]);
 
   const handleParticipate = () => {
-    setPhase('quiz');
+    if (quizConfig?.questions?.length) {
+      setPhase('quiz');
+    } else {
+      setPhase('form');
+    }
   };
 
-  // Unused answer handler
+  useEffect(() => {
+    setShowFormModal(phase === 'form');
+  }, [phase]);
+
+  const handleQuizComplete = useCallback((result: QuizCompletionSummary) => {
+    setScore(result.score);
+    setTotalQuestions(result.total);
+    setQuizResponses(result.responses);
+    setPhase('form');
+  }, []);
+
+  const handleFormClose = useCallback(() => {
+    setShowFormModal(false);
+    setPhase('participate');
+  }, []);
 
   const handleFormSubmit = async (formData: Record<string, string>) => {
     setParticipationLoading(true);
@@ -47,7 +70,7 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
       if (campaign.id) {
         await createParticipation({
           campaign_id: campaign.id,
-          form_data: { ...formData, score },
+          form_data: { ...formData, score, totalQuestions, quizResponses },
           user_email: formData.email
         });
       }
@@ -63,6 +86,8 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
 
   const handleReplay = () => {
     setScore(0);
+    setTotalQuestions(0);
+    setQuizResponses([]);
     setPhase('participate');
   };
 
@@ -83,11 +108,18 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
           </div>
         )}
 
-        {/* Quiz phase - Supprimé, passer directement au formulaire */}
-        {phase === 'quiz' && (() => {
-          setPhase('form');
-          return null;
-        })()}
+        {phase === 'quiz' && (
+          <div className="relative z-10 h-full flex items-center justify-center p-4 overflow-y-auto">
+            <div className="w-full max-w-3xl">
+              <QuizGame
+                config={quizConfig}
+                design={campaign.design}
+                onGameComplete={handleQuizComplete}
+                showResultsScreen={false}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Form phase - use modal component to keep look consistent */}
         <FormHandler
@@ -95,7 +127,7 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
           campaign={campaign}
           fields={fields}
           participationLoading={participationLoading}
-          onClose={() => setShowFormModal(false)}
+          onClose={handleFormClose}
           onSubmit={handleFormSubmit}
         />
 
@@ -105,7 +137,9 @@ const FunnelQuizParticipate: React.FC<FunnelQuizParticipateProps> = ({ campaign,
             <div className="bg-white/90 backdrop-blur px-6 py-5 rounded-xl shadow">
               <div className="text-lg font-semibold text-gray-800 mb-2">Merci pour votre participation !</div>
               {showScore && (
-                <div className="text-sm text-gray-700 mb-3">Score: {score}</div>
+                <div className="text-sm text-gray-700 mb-3">
+                  Score: {score}{totalQuestions ? `/${totalQuestions}` : ''}
+                </div>
               )}
               <div className="flex justify-center">
                 <button

--- a/src/components/shared/TemplatedQuiz.tsx
+++ b/src/components/shared/TemplatedQuiz.tsx
@@ -169,7 +169,36 @@ const TemplatedQuiz: React.FC<TemplatedQuizProps> = ({
     ]
   };
 
-  const questions = quizConfig.questions || [];
+  const normalizeQuestion = (question: any, questionIndex: number) => {
+    const answersSource = Array.isArray(question?.answers) && question.answers.length > 0
+      ? question.answers
+      : Array.isArray(question?.options)
+        ? question.options
+        : [];
+
+    const normalizedAnswers = answersSource.map((answer: any, answerIndex: number) => ({
+      ...answer,
+      id: answer?.id ?? `${question?.id ?? questionIndex}-${answerIndex}`,
+      text: answer?.text ?? answer?.label ?? answer?.value ?? `Option ${answerIndex + 1}`,
+      image: answer?.image ?? answer?.mediaUrl ?? answer?.picture ?? undefined,
+      isCorrect: typeof answer?.isCorrect === 'boolean'
+        ? answer.isCorrect
+        : !!answer?.correct
+    }));
+
+    return {
+      ...question,
+      id: question?.id ?? questionIndex,
+      question: question?.question ?? question?.text ?? question?.title ?? `Question ${questionIndex + 1}`,
+      answers: normalizedAnswers,
+      image: question?.image ?? question?.mediaUrl ?? question?.picture ?? undefined
+    };
+  };
+
+  const questions = Array.isArray(quizConfig?.questions)
+    ? quizConfig.questions.map(normalizeQuestion)
+    : [];
+
   const currentQuestion = questions[0] || {};
   const answers = currentQuestion.answers || [];
   const letters = ['A', 'B', 'C', 'D', 'E', 'F'];


### PR DESCRIPTION
## Summary
- normalize quiz question data in the inline template so editor previews display configured questions
- pass synchronized campaign data to the design canvas and expose quiz completion callbacks in game components
- rework the quiz funnel preview to render the quiz phase, track results, and surface the contact form/thank-you states

## Testing
- `npm ci` *(fails: onnxruntime download blocked by ENETUNREACH)*
- `npm test` *(fails: missing dependencies because npm ci could not complete)*

------
https://chatgpt.com/codex/tasks/task_b_68cbc57fb9a4833193e05b60442ba1cf