### PR TITLE
Add bottom footer bar to editors

### DIFF
--- a/src/components/QuizEditor/modules/ModularCanvas.tsx
+++ b/src/components/QuizEditor/modules/ModularCanvas.tsx
@@ -417,6 +417,16 @@ const renderModule = (m: Module, onUpdate: (patch: Partial<Module>) => void, dev
           onModuleUpdate={(_id, patch) => onUpdate(patch)}
         />
       );
+    case 'BlocPiedDePage':
+      return (
+        <QuizModuleRenderer
+          modules={[m]}
+          previewMode={false}
+          device={device}
+          onModuleClick={() => {}}
+          onModuleUpdate={(_id, patch) => onUpdate(patch)}
+        />
+      );
     default:
       return null;
   }
@@ -612,9 +622,10 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
     return () => window.cancelAnimationFrame(id);
   }, [modules, onUpdate, device]);
 
-  // Séparer les modules Logo des autres modules
+  // Séparer les modules Logo, PiedDePage et autres modules
   const logoModules = React.useMemo(() => modules.filter(m => m.type === 'BlocLogo'), [modules]);
-  const regularModules = React.useMemo(() => modules.filter(m => m.type !== 'BlocLogo'), [modules]);
+  const footerModules = React.useMemo(() => modules.filter(m => m.type === 'BlocPiedDePage'), [modules]);
+  const regularModules = React.useMemo(() => modules.filter(m => m.type !== 'BlocLogo' && m.type !== 'BlocPiedDePage'), [modules]);
   
   const modulePaddingClass = device === 'mobile' ? 'p-0' : 'p-4';
   const single = regularModules.length === 1;
@@ -936,10 +947,34 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
           );
         })}
         </div>
-        {regularModules.length === 0 && logoModules.length === 0 && (
+        {regularModules.length === 0 && logoModules.length === 0 && footerModules.length === 0 && (
           <div className="text-xs text-gray-500 text-center py-8">Aucun module. Utilisez l'onglet Éléments pour en ajouter.</div>
         )}
       </div>
+      
+      {/* Modules Pied de page - positionnés en pleine largeur en bas */}
+      {footerModules.map((m) => (
+        <div 
+          key={m.id}
+          className={`relative group ${selectedModuleId === m.id ? 'ring-2 ring-[#841b60]/30' : ''}`}
+          style={{ width: '100vw', marginLeft: 'calc(-50vw + 50%)', marginRight: 'calc(-50vw + 50%)' }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(m);
+          }}
+        >
+          <Toolbar
+            visible={selectedModuleId === m.id}
+            layoutWidth="full"
+            onWidthChange={() => {}}
+            onDelete={() => onDelete(m.id)}
+            expanded={openToolbarFor === m.id}
+            onToggle={() => setOpenToolbarFor((prev) => (prev === m.id ? null : m.id))}
+            isMobile={device === 'mobile'}
+          />
+          {renderModule(m, (patch) => onUpdate(m.id, patch), device)}
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/ScratchCardEditor/modules/ModularCanvas.tsx
+++ b/src/components/ScratchCardEditor/modules/ModularCanvas.tsx
@@ -624,8 +624,9 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
     return () => window.cancelAnimationFrame(id);
   }, [modules, onUpdate, device]);
 
-  // Séparer les modules Logo des autres modules
+  // Séparer les modules Logo, PiedDePage et autres modules
   const logoModules = React.useMemo(() => modules.filter(m => m.type === 'BlocLogo'), [modules]);
+  const footerModules = React.useMemo(() => modules.filter(m => m.type === 'BlocPiedDePage'), [modules]);
   const regularModules = React.useMemo(() => modules.filter(m => m.type !== 'BlocLogo' && m.type !== 'BlocPiedDePage'), [modules]);
   
   const modulePaddingClass = device === 'mobile' ? 'p-0' : 'p-4';
@@ -949,10 +950,34 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
           );
         })}
         </div>
-        {regularModules.length === 0 && logoModules.length === 0 && (
+        {regularModules.length === 0 && logoModules.length === 0 && footerModules.length === 0 && (
           <div className="text-xs text-gray-500 text-center py-8">Aucun module. Utilisez l'onglet Éléments pour en ajouter.</div>
         )}
       </div>
+      
+      {/* Modules Pied de page - positionnés en pleine largeur en bas */}
+      {footerModules.map((m) => (
+        <div 
+          key={m.id}
+          className={`relative group ${selectedModuleId === m.id ? 'ring-2 ring-[#841b60]/30' : ''}`}
+          style={{ width: '100vw', marginLeft: 'calc(-50vw + 50%)', marginRight: 'calc(-50vw + 50%)' }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(m);
+          }}
+        >
+          <Toolbar
+            visible={selectedModuleId === m.id}
+            layoutWidth="full"
+            onWidthChange={() => {}}
+            onDelete={() => onDelete(m.id)}
+            expanded={openToolbarFor === m.id}
+            onToggle={() => setOpenToolbarFor((prev) => (prev === m.id ? null : m.id))}
+            isMobile={device === 'mobile'}
+          />
+          {renderModule(m, (patch) => onUpdate(m.id, patch), device)}
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
Render 'BlocPiedDePage' modules as a full-width band aligned to the bottom of the canvas in Quiz and ScratchCard editors.

---
<a href="https://cursor.com/background-agent?bcId=bc-136cd09f-769b-4a8a-af42-c5798a1312f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-136cd09f-769b-4a8a-af42-c5798a1312f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

