### PR TITLE
Add bottom footer bar to editors

### DIFF
--- a/src/components/QuizEditor/modules/ModularCanvas.tsx
+++ b/src/components/QuizEditor/modules/ModularCanvas.tsx
@@ -417,6 +417,16 @@ const renderModule = (m: Module, onUpdate: (patch: Partial<Module>) => void, dev
           onModuleUpdate={(_id, patch) => onUpdate(patch)}
         />
       );
+    case 'BlocPiedDePage':
+      return (
+        <QuizModuleRenderer
+          modules={[m]}
+          previewMode={false}
+          device={device}
+          onModuleClick={() => {}}
+          onModuleUpdate={(_id, patch) => onUpdate(patch)}
+        />
+      );
     default:
       return null;
   }
@@ -612,9 +622,13 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
     return () => window.cancelAnimationFrame(id);
   }, [modules, onUpdate, device]);
 
-  // Séparer les modules Logo des autres modules
+  // Séparer les modules Logo et Pied de page des autres modules
   const logoModules = React.useMemo(() => modules.filter(m => m.type === 'BlocLogo'), [modules]);
-  const regularModules = React.useMemo(() => modules.filter(m => m.type !== 'BlocLogo'), [modules]);
+  const footerModules = React.useMemo(() => modules.filter(m => m.type === 'BlocPiedDePage'), [modules]);
+  const regularModules = React.useMemo(
+    () => modules.filter(m => m.type !== 'BlocLogo' && m.type !== 'BlocPiedDePage'),
+    [modules]
+  );
   
   const modulePaddingClass = device === 'mobile' ? 'p-0' : 'p-4';
   const single = regularModules.length === 1;
@@ -936,10 +950,34 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
           );
         })}
         </div>
-        {regularModules.length === 0 && logoModules.length === 0 && (
+        {regularModules.length === 0 && logoModules.length === 0 && footerModules.length === 0 && (
           <div className="text-xs text-gray-500 text-center py-8">Aucun module. Utilisez l'onglet Éléments pour en ajouter.</div>
         )}
       </div>
+
+      {/* Modules Pied de page - positionnés en pleine largeur en dessous */}
+      {footerModules.map((m) => (
+        <div 
+          key={m.id}
+          className={`relative group ${selectedModuleId === m.id ? 'ring-2 ring-[#0ea5b7]/30' : ''}`}
+          style={{ width: '100vw', marginLeft: 'calc(-50vw + 50%)', marginRight: 'calc(-50vw + 50%)' }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(m);
+          }}
+        >
+          <Toolbar
+            visible={selectedModuleId === m.id}
+            layoutWidth="full"
+            onWidthChange={() => {}}
+            onDelete={() => onDelete(m.id)}
+            expanded={openToolbarFor === m.id}
+            onToggle={() => setOpenToolbarFor((prev) => (prev === m.id ? null : m.id))}
+            isMobile={device === 'mobile'}
+          />
+          {renderModule(m, (patch) => onUpdate(m.id, patch), device)}
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/ScratchCardEditor/modules/ModularCanvas.tsx
+++ b/src/components/ScratchCardEditor/modules/ModularCanvas.tsx
@@ -624,9 +624,13 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
     return () => window.cancelAnimationFrame(id);
   }, [modules, onUpdate, device]);
 
-  // Séparer les modules Logo des autres modules
+  // Séparer les modules Logo et Pied de page des autres modules
   const logoModules = React.useMemo(() => modules.filter(m => m.type === 'BlocLogo'), [modules]);
-  const regularModules = React.useMemo(() => modules.filter(m => m.type !== 'BlocLogo' && m.type !== 'BlocPiedDePage'), [modules]);
+  const footerModules = React.useMemo(() => modules.filter(m => m.type === 'BlocPiedDePage'), [modules]);
+  const regularModules = React.useMemo(
+    () => modules.filter(m => m.type !== 'BlocLogo' && m.type !== 'BlocPiedDePage'),
+    [modules]
+  );
   
   const modulePaddingClass = device === 'mobile' ? 'p-0' : 'p-4';
   const single = regularModules.length === 1;
@@ -949,10 +953,34 @@ const ModularCanvas: React.FC<ModularCanvasProps> = ({ screen, modules, onUpdate
           );
         })}
         </div>
-        {regularModules.length === 0 && logoModules.length === 0 && (
+        {regularModules.length === 0 && logoModules.length === 0 && footerModules.length === 0 && (
           <div className="text-xs text-gray-500 text-center py-8">Aucun module. Utilisez l'onglet Éléments pour en ajouter.</div>
         )}
       </div>
+
+      {/* Modules Pied de page - positionnés en pleine largeur en dessous */}
+      {footerModules.map((m) => (
+        <div 
+          key={m.id}
+          className={`relative group ${selectedModuleId === m.id ? 'ring-2 ring-[#0ea5b7]/30' : ''}`}
+          style={{ width: '100vw', marginLeft: 'calc(-50vw + 50%)', marginRight: 'calc(-50vw + 50%)' }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(m);
+          }}
+        >
+          <Toolbar
+            visible={selectedModuleId === m.id}
+            layoutWidth="full"
+            onWidthChange={() => {}}
+            onDelete={() => onDelete(m.id)}
+            expanded={openToolbarFor === m.id}
+            onToggle={() => setOpenToolbarFor((prev) => (prev === m.id ? null : m.id))}
+            isMobile={device === 'mobile'}
+          />
+          {renderModule(m, (patch) => onUpdate(m.id, patch), device)}
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
Render 'Pied de page' modules as a full-width, bottom-aligned band in Quiz and Scratch editors, mirroring the 'Logo' module's visual style.

The existing 'Logo' module uses a full-width band at the top of the canvas. This PR extends that visual treatment to the 'Pied de page' module, positioning it at the bottom of the canvas to provide a consistent and distinct layout for these special modules, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-515c3d14-9bd8-4df5-bf70-06b64b8cbbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-515c3d14-9bd8-4df5-bf70-06b64b8cbbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

